### PR TITLE
[FE] Create README & Add twin.macro pre-setting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+## twin.macro 사전 작업
+
+### 1. 'Tailwind Twin IntelliSense'라는 VSCode 플러그인을 설치한다
+https://marketplace.visualstudio.com/items?itemName=lightyen.tailwindcss-intellisense-twin
+
+### 2. settings.json에 세팅을 추가한다
+
+```Ctrl + Shift + P```를 눌러서 Show all commands 검색창 열기.
+
+![image](https://github.com/codestates-seb/seb44_pre_022/assets/65957855/ef640df4-5e8d-4c7b-a330-743609d25e34)
+
+'Preferences: Open Settings (JSON)'이라고 검색 & 열기.
+
+settings.json 파일 맨 아래에 해당 코드 추가
+
+```json
+/* Tailwind CSS IntelliSense 설정 */
+"scss.validate": false,
+"editor.quickSuggestions": {
+    "strings": true
+},
+"editor.autoClosingQuotes": "always",
+"tailwindCSS.experimental.classRegex": [
+    "tw`([^`]*)", // tw`...`
+    "tw='([^']*)", // <div tw="..." />
+    "tw={'([^'}]*)", // <div tw={"..."} />
+    "tw\\.\\w+`([^`]*)", // tw.xxx`...`
+    "tw\\(.*?\\)`([^`]*)" // tw(Component)`...`
+],
+"tailwindCSS.includeLanguages": {
+  "typescript": "javascript",
+  "typescriptreact": "javascript"
+}
+```
+
+↓ 아래 사진처럼 되어 있으면 OK ↓
+
+![image](https://github.com/codestates-seb/seb44_pre_022/assets/65957855/d9e238ea-8db4-467b-9c5f-6230268fd7cf)
+
+
+### 3. VSCode 하단의 CRLF를 LF로 바꾼다
+
+[Before] 👎
+![image](https://github.com/codestates-seb/seb44_pre_022/assets/65957855/0b44894f-ff3d-4196-8544-6704a36f97a6)
+
+[After] 👍
+![image](https://github.com/codestates-seb/seb44_pre_022/assets/65957855/ebca1816-1ee3-4165-9dfe-34c2caac3a65)
+
+Prettier에서는 오작동 방지를 위해 CRLF 대신 LF를 사용할 것을 권장하고 있다. 그래서 (굳이 tw 때문이 아니더라도) 모든 .tsx 파일의 설정을 LF로 바꿔놓는 게 좋다.
+
+### 4. 결과
+(예시: w-40 / text-center / bg-pink-500)
+![tw 자동완성](https://github.com/codestates-seb/seb44_pre_022/assets/65957855/47e8668e-cc0a-4a48-922d-bb169dfcd417)
+
+Tailwind 코드를 넣었을 때 이런 식으로 자동 완성이 되는지 확인해야 한다.


### PR DESCRIPTION
## twin.macro 사전 작업

### 1. 'Tailwind Twin IntelliSense'라는 VSCode 플러그인을 설치한다
https://marketplace.visualstudio.com/items?itemName=lightyen.tailwindcss-intellisense-twin

<br>

### 2. settings.json에 세팅을 추가한다

```Ctrl + Shift + P```를 눌러서 Show all commands 검색창 열기.

![246432039-ef640df4-5e8d-4c7b-a330-743609d25e34](https://github.com/codestates-seb/seb44_main_016/assets/65957855/be9fb918-79e4-4d6d-8d61-4e518d816d90)


'Preferences: Open Settings (JSON)'이라고 검색 & 열기.

settings.json 파일 맨 아래에 해당 코드 추가

```json
/* Tailwind CSS IntelliSense 설정 */
"scss.validate": false,
"editor.quickSuggestions": {
    "strings": true
},
"editor.autoClosingQuotes": "always",
"tailwindCSS.experimental.classRegex": [
    "tw`([^`]*)", // tw`...`
    "tw='([^']*)", // <div tw="..." />
    "tw={'([^'}]*)", // <div tw={"..."} />
    "tw\\.\\w+`([^`]*)", // tw.xxx`...`
    "tw\\(.*?\\)`([^`]*)" // tw(Component)`...`
],
"tailwindCSS.includeLanguages": {
  "typescript": "javascript",
  "typescriptreact": "javascript"
}
```

↓ 아래 사진처럼 되어 있으면 OK ↓

![246433364-d9e238ea-8db4-467b-9c5f-6230268fd7cf](https://github.com/codestates-seb/seb44_main_016/assets/65957855/8e7ff4fb-327f-4de5-85a9-36ae39b596ab)


<br>

### 3. VSCode 하단의 CRLF를 LF로 바꾼다

[Before] 👎
![246434569-0b44894f-ff3d-4196-8544-6704a36f97a6](https://github.com/codestates-seb/seb44_main_016/assets/65957855/c9e010fe-b261-42cc-a530-bf256a533a83)


[After] 👍
![246434625-ebca1816-1ee3-4165-9dfe-34c2caac3a65](https://github.com/codestates-seb/seb44_main_016/assets/65957855/b3ef495e-3eb8-414a-a19b-f2ff32f35868)


Prettier에서는 오작동 방지를 위해 CRLF 대신 LF를 사용할 것을 권장하고 있다. 그래서 (굳이 tw 때문이 아니더라도) 모든 .tsx 파일의 설정을 LF로 바꿔놓는 게 좋다.

<br>

### 🎉 4. 결과 🎉
(예시: w-40 / text-center / bg-pink-500)
![246430468-47e8668e-cc0a-4a48-922d-bb169dfcd417](https://github.com/codestates-seb/seb44_main_016/assets/65957855/fc277e04-5306-43e3-b674-538a87a5746f)


Tailwind 코드를 넣었을 때 이런 식으로 자동 완성이 되는지 확인해야 한다.