### PR TITLE
[FE] design: 최상위 컴포넌트 너비 지정

### DIFF
--- a/client/src/components/common/PageTemplate.tsx
+++ b/client/src/components/common/PageTemplate.tsx
@@ -1,0 +1,5 @@
+import tw from 'twin.macro';
+
+export const FlexPage = tw.div`
+w-full h-full
+`;

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,8 +1,25 @@
 import type { AppProps } from 'next/app';
+import GlobalStyles from '../styles/GlobalStyles';
+
+import tw from 'twin.macro';
+
+const RootScreen = tw.div`
+flex justify-center w-[100vw] min-h-[100vh]
+`;
+
+const AppContainer = tw.div`
+max-w-[1140px] w-full
+`;
 
 const App = ({ Component, pageProps }: AppProps) => (
   <>
-    <Component {...pageProps} />
+    {/*모든 ReactDOM에 margin: 0; padding: 0; box-sizing: border-box; 적용 */}
+    <GlobalStyles />
+    <RootScreen>
+      <AppContainer>
+        <Component {...pageProps} />
+      </AppContainer>
+    </RootScreen>
   </>
 );
 

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,11 +1,16 @@
 import tw from 'twin.macro';
+import { FlexPage } from '../components/common/PageTemplate';
 
-const App = () => (
-  <div tw='flex flex-col justify-center h-full gap-y-5'>
-    <button>Submit</button>
-    <button>Submit</button>
-    <button>Submit</button>
-  </div>
-);
+const HomePageContainer = tw(FlexPage)`
+flex flex-col justify-center bg-[#F0F3F8]
+`;
 
-export default App;
+export default function HomePage() {
+  return (
+    <HomePageContainer>
+      <button>Submit</button>
+      <button>Submit</button>
+      <button>Submit</button>
+    </HomePageContainer>
+  );
+}

--- a/client/src/pages/test/index.tsx
+++ b/client/src/pages/test/index.tsx
@@ -1,0 +1,7 @@
+export default function Test() {
+  return (
+    <div>
+      <h1>@ZEROHIP@</h1>
+    </div>
+  );
+}

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -1,0 +1,15 @@
+import { Global } from '@emotion/react';
+
+const GlobalStyles = () => (
+  <Global
+    styles={`
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+    `}
+  />
+);
+
+export default GlobalStyles;


### PR DESCRIPTION
[_app.tsx]
 * AppContainer: max-w-[1140px] w-full 적용
 * [GlobalStyles.tsx]: 모든 ReactDOM에 margin: 0; padding: 0; box-sizing: border-box; 적용

[PageTemplate.tsx]
 * Add FlexPage : `w-full h-full` TailwindCSS 코드 변수화

# 비고
급하게 PR 하느라 템플릿을 활용하지 못했습니다.

# ex) 로그인 C 구현 

프론트엔드 구현 화면 스크린샷 (백엔드 생략 가능, 해당 항목 지워주셔도 됩니다.)

<br/>

## 구현한 기능
1. 로그인시 화면 변경
    - 로그인 상태 받아와 분기 처리
3. 구현 2

<br/>

## 비고
