### PR TITLE
[FE] design & feat: 게시글 편집 페이지(editor) 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,6 +26,7 @@
         "@tanstack/eslint-plugin-query": "^4.29.9",
         "@types/node": "^18.15.11",
         "@types/react": "^18.0.33",
+        "@types/react-datepicker": "^4.11.2",
         "@typescript-eslint/eslint-plugin": "^5.60.1",
         "@typescript-eslint/parser": "^5.60.1",
         "babel-loader": "^9.1.2",
@@ -1275,6 +1276,18 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-datepicker": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.11.2.tgz",
+      "integrity": "sha512-ELYyX3lb3K1WltqdlF1hbnaDGgzlF6PIR5T4W38cSEcfrQDIrPE+Ioq5pwRe/KEJ+ihHMjvTVZQkwJx0pWMNHQ==",
+      "dev": true,
+      "dependencies": {
+        "@popperjs/core": "^2.9.2",
+        "@types/react": "*",
+        "date-fns": "^2.0.1",
+        "react-popper": "^2.2.5"
       }
     },
     "node_modules/@types/scheduler": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.4.0",
         "next": "^13.3.0",
         "react": "^18.2.0",
+        "react-datepicker": "^4.15.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.1"
       },
@@ -1121,6 +1122,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
@@ -2222,6 +2232,11 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2322,6 +2337,21 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4228,7 +4258,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4634,7 +4663,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4708,6 +4736,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.15.0.tgz",
+      "integrity": "sha512-kysEqVv6wRQkmAyn0wJi4Xx+JjBPBtXWfQSfh6sR3wdzZX1/LjYTPmaurnVI6ao177ecompg8ze7NCgtEGW78A==",
+      "dependencies": {
+        "@popperjs/core": "^2.9.2",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.24.0",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.12.2",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18",
+        "react-dom": "^16.9.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -4720,10 +4765,42 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-onclickoutside": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
+      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/react-onclickoutside/blob/master/FUNDING.md"
+      },
+      "peerDependencies": {
+        "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
+        "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
     },
     "node_modules/react-redux": {
       "version": "8.1.1",
@@ -5768,6 +5845,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.4.0",
     "next": "^13.3.0",
     "react": "^18.2.0",
+    "react-datepicker": "^4.15.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.1"
   },

--- a/client/package.json
+++ b/client/package.json
@@ -29,6 +29,7 @@
     "@tanstack/eslint-plugin-query": "^4.29.9",
     "@types/node": "^18.15.11",
     "@types/react": "^18.0.33",
+    "@types/react-datepicker": "^4.11.2",
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.60.1",
     "babel-loader": "^9.1.2",

--- a/client/src/components/common/PageTemplate.tsx
+++ b/client/src/components/common/PageTemplate.tsx
@@ -1,5 +1,5 @@
 import tw from 'twin.macro';
 
 export const FlexPage = tw.div`
-w-full h-full
+flex w-full h-full bg-[#F0F3F8]
 `;

--- a/client/src/pages/editor/index.tsx
+++ b/client/src/pages/editor/index.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+
+import tw from 'twin.macro';
+import axios from 'axios';
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+
+import { FlexPage } from '../../components/common/PageTemplate';
+
+const EditorPageContainer = tw(FlexPage)``;
+
+const AsideFrame = tw.aside`
+w-[367px] h-full bg-pink-500
+`;
+
+const EditorContainer = tw.form`
+w-full flex flex-col p-16 gap-5
+`;
+
+const Row = tw.section`
+w-full flex justify-evenly
+`;
+
+const RadioContainer = tw.section`
+flex gap-5
+`;
+
+const ImgSample = tw.img`
+w-[153px] h-[153px]  bg-pink-500 rounded-[10px]
+`;
+
+const articleTypeOptions: { value: number; label: string }[] = [
+  { value: 1, label: '가계부' },
+  { value: 2, label: '절약 팁' },
+  { value: 3, label: '허락해줘!' },
+];
+const faTypeOptions: { value: number; label: string }[] = [
+  { value: 1, label: '지출' },
+  { value: 2, label: '수입' },
+];
+const scopeOptions: { value: number; label: string }[] = [
+  { value: 1, label: '가계부에만' },
+  { value: 2, label: '타임라인에도' },
+];
+
+export default function EditorPage() {
+  // 일부 값들은 Enum으로 바꾸는 걸 권장
+
+  const [articleType, setArticleType] = React.useState(1); // 가계부/절약팁/허락해줘 (라디오 버튼)
+  /* ↓ 'articleType=가계부'일 경우에만 표시 ↓ */
+  const [faRecId, setFaRecId] = React.useState(1); // 가계부의 고유번호
+  const [faDate, setFaDate] = React.useState(new Date()); // 날짜 (시간 미포함)
+  const [category, setCategory] = React.useState(''); // 카테고리명
+  const [price, setPrice] = React.useState(0); // 금액
+  const [faType, setFaType] = React.useState(1); // 지출/수입 (라디오 버튼)
+  const [title, setTitle] = React.useState(''); // 제목(내역)
+  /* ↓ 모든 articleType에 표시 ↓ */
+  // const [images, setImages] = React.useState([]); // 이미지 (0~4장)
+  const [content, setContent] = React.useState(''); // 내용(본문)
+  const [scope, setScope] = React.useState(1); // 가계부에만/타임라인에도
+
+  const handleChangeArticleType = (id: number) => {
+    setArticleType(id);
+  };
+  const handleChangeFaRecId = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedFaRecId = parseInt(e.target.value, 10);
+    setFaRecId(selectedFaRecId);
+  };
+  const handleChangeDate = (date: Date) => {
+    setFaDate(date);
+  };
+  const handleChangeCategory = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setCategory(e.target.value);
+  };
+  const handleChangePrice = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const enteredPrice = parseInt(e.target.value, 10);
+    setPrice(enteredPrice);
+  };
+  const handleChangeFaType = (id: number) => {
+    setFaType(id);
+  };
+  const handleChangeTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+  const handleChangeContent = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value);
+  };
+  const handleChangeScope = (id: number) => {
+    setScope(id);
+  };
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (articleType === 1) {
+        // 가계부
+        const body = {
+          financialRecordId: faRecId,
+          category,
+          financialRecordDate: faDate,
+          price,
+          content,
+          scope,
+          // imageId: , (미구현 & 필수 사항 아님)
+          userId: 0,
+          // "voteId": , (가계부에는 절약/Flex 기능을 사용하지 않음)
+          // "financialRecordArticleHashTagId": , (미구현 & 필수 사항 아님)
+        };
+        await axios.post(
+          `http://localhost:8080/financialrecord/${faRecId}/article/'`,
+          body
+        );
+      } else {
+        // 절약팁/허락해줘
+        const body = {
+          content,
+          scope,
+          userId: 0,
+        };
+        await axios.post('http://localhost:8080/feedArticles/article', body);
+      }
+      console.log(`Requset 성공: 게시글 작성`);
+    } catch (error) {
+      console.error('Requset 에러 발생:', error);
+    }
+  };
+
+  return (
+    <EditorPageContainer>
+      <AsideFrame />
+      <EditorContainer onSubmit={handleSubmit}>
+        <Row>
+          {/* 가계부/절약팁/허락해줘 (라디오 버튼) */}
+          <RadioContainer>
+            {articleTypeOptions.map((option) => (
+              <label key={option.value}>
+                <input
+                  type='radio'
+                  value={option.value}
+                  checked={articleType === option.value}
+                  onChange={() => handleChangeArticleType(option.value)}
+                />
+                {option.label}
+              </label>
+            ))}
+          </RadioContainer>
+        </Row>
+        {/* ↓ 'articleType=가계부'일 경우에만 표시 ↓ */}
+        {/* 작성할 가계부 (셀렉트) */}
+        <select name='faRecs' id='faRec' onChange={handleChangeFaRecId}>
+          <option value='1'>가계부1</option>
+          <option value='2'>가계부2</option>
+          <option value='3'>가계부3</option>
+        </select>
+        <Row>
+          {/* 날짜 (시간 미포함) */}
+          <DatePicker selected={faDate} onChange={handleChangeDate} />
+          {/* 카테고리 */}
+          <select
+            name='categories'
+            id='category'
+            onChange={handleChangeCategory}
+          >
+            <option value='식비'>식비</option>
+            <option value='교통비'>교통비</option>
+            <option value='교육비'>교육비</option>
+            <option value='여가비'>여가비</option>
+          </select>
+        </Row>
+        <Row>
+          {/* 금액 */}
+          <input
+            type='number'
+            name='price'
+            placeholder='금액을 입력하세요'
+            min='0'
+            value={price}
+            onChange={handleChangePrice}
+          />
+          {/* 지출/수입 (라디오 버튼) */}
+          <RadioContainer>
+            {faTypeOptions.map((option) => (
+              <label key={option.value}>
+                <input
+                  type='radio'
+                  value={option.value}
+                  checked={faType === option.value}
+                  onChange={() => handleChangeFaType(option.value)}
+                />
+                {option.label}
+              </label>
+            ))}
+          </RadioContainer>
+        </Row>
+        {/* 내역(제목) */}
+        <input
+          type='text'
+          placeholder='제목을 입력하세요'
+          value={title}
+          onChange={handleChangeTitle}
+        />
+        {/* ↓ 모든 articleType에 표시 ↓ */}
+        {/* 이미지 */}
+        <Row>
+          <ImgSample />
+          <ImgSample />
+          <ImgSample />
+          <ImgSample />
+        </Row>
+        {/* 내용(본문) */}
+        <textarea
+          placeholder='내용을 입력해주세요'
+          value={content}
+          onChange={handleChangeContent}
+        />
+        {/* 공개 범위 (라디오 버튼) */}
+        <RadioContainer>
+          {scopeOptions.map((option) => (
+            <label key={option.value}>
+              <input
+                type='radio'
+                value={option.value}
+                checked={faType === option.value}
+                onChange={() => handleChangeScope(option.value)}
+              />
+              {option.label}
+            </label>
+          ))}
+        </RadioContainer>
+        {/* Submit 버튼 */}
+        <button type='submit'>편집 완료</button>
+      </EditorContainer>
+    </EditorPageContainer>
+  );
+}

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -2,7 +2,7 @@ import tw from 'twin.macro';
 import { FlexPage } from '../components/common/PageTemplate';
 
 const HomePageContainer = tw(FlexPage)`
-flex flex-col justify-center bg-[#F0F3F8]
+flex-col justify-center bg-[#F0F3F8]
 `;
 
 export default function HomePage() {


### PR DESCRIPTION
# design & feat: 게시글 편집 페이지(editor) 구현

![image](https://github.com/codestates-seb/seb44_main_016/assets/65957855/07f25552-125f-449c-9d51-35f24e8c14bb)

뼈대랑 기본적인 기능만 구현하였습니다. 추후에 살을 입히고, 개선할 부분은 따로 이슈를 파서 업데이트할 예정입니다.

<br/>

## 구현한 기능
### 1. [editor/index.tsx]
* 전체적인 UI 및 기능, HTTP Request 구현

### 2. [PageTemplate.tsx]
* FlexPage: flex 적용 및 배경색 bg-[#F0F3F8] 추가

<br/>

## 비고
* 기능 추가 필요
  * 날짜는 있는데 시간 설정이 없음
  * 본문에서 해시태그만 인식 & 추출하는 기능
  * 카테고리 종류가 더 다양해야 함
  * 절약팁/허락해줘 선택지를 눌렀을 경우 일부 항목들이 숨겨지지 않음
  * 실제 이미지 추가(업로드) 기능 없음

* 추후 개선 필요
  * 디자인, Enum화, 리팩토링 등
  * `http://localhost:8080`을 실제 서버 오리진으로 바꿔야 함
  * AsideFrame을 실제 `<Aside>`로 바꿔야 함

* 추후 검토 필요
  * 실제 서버와의 정상적인 request & response 여부

