### PR TITLE
[FE] style-7 : 공통 스타일 지정 및 input design

### DIFF
--- a/client/src/styles/CommonStyles.tsx
+++ b/client/src/styles/CommonStyles.tsx
@@ -1,0 +1,41 @@
+import styled from '@emotion/styled';
+import { InputHTMLAttributes } from 'react';
+import tw from 'twin.macro';
+
+interface ButtonProps {
+  small?: boolean;
+  large?: boolean;
+}
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+const CommonStyles = {
+  SubmitBtn: styled.button<ButtonProps>((props) => [
+    tw`relative inline-block text-white p-4 rounded-full font-normal border-2 border-primary border-solid overflow-hidden bg-white z-10 hover:(text-primary bg-white duration-700 font-bold) before:(content-[''] absolute w-80 h-80 -left-16 -top-16 -z-10 rounded-full bg-primary translate-x-full translate-y-full transition-all duration-700) before:hover:( top-10 left-10 transition-all duration-700)`,
+    props.small
+      ? tw`w-auto px-[1.125rem] py-[0.68rem] before:(w-32 h-32 -left-1/2 -top-1/2) before:hover:(top-16 left-10)`
+      : props.large
+      ? tw`w-full max-w-xl before:(w-[1000px] h-[1000px] -left-1/2 -top-[1000%]) before:hover:(top-16 left-10)`
+      : tw`w-40`,
+  ]),
+
+  InputText: styled.input<InputProps>`
+    ${tw`bg-white rounded-full w-full px-7 py-4 border-line-gray border border-solid text-fontColor-gray01 placeholder:text-fontColor-gray07 focus:outline-primary `}
+  `,
+
+  Textarea: styled.textarea<React.HTMLProps<HTMLTextAreaElement>>`
+    ${tw`bg-white rounded-default w-full px-7 py-4 text-fontColor-gray01 placeholder:text-fontColor-gray07 border-line-gray resize-none min-h-[120px] focus:outline-primary`}
+  `,
+
+  RadioBtnLabel: tw.label`
+  flex align-middle font-normal
+  `,
+
+  RadioBtn: tw.input`
+  appearance-none relative w-[18px] h-[18px] border-line-gray rounded-full border border-solid bg-white cursor-pointer mr-[10px]
+
+  checked:( border-primary border-4)
+  `,
+};
+
+export default CommonStyles;

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -3,11 +3,75 @@ import { Global } from '@emotion/react';
 const GlobalStyles = () => (
   <Global
     styles={`
+    @import url('https://webfontworld.github.io/pretendard/Pretendard.css');
+
       * {
         margin: 0;
         padding: 0;
         box-sizing: border-box;
       }
+
+      :root {
+        color: #333;
+        font-family: 'Pretendard';
+        font-weight: 400;
+      }
+
+      li {
+        list-style: none;
+      }
+      img,
+      fieldset,
+      iframe {
+        display: block;
+        border: 0 none;
+      }
+      
+      a {
+        color: inherit;
+        text-decoration: none;
+        cursor: pointer;
+      }
+      
+      em,
+      address {
+        font-style: normal;
+      }
+      
+      article,
+      aside,
+      details,
+      figcaption,
+      figure,
+      footer,
+      header,
+      hgroup,
+      menu,
+      nav,
+      section,
+      svg {
+        display: block;
+      }
+      
+      label {
+        cursor: pointer;
+      }
+      
+      button {
+        cursor: pointer;
+        background: none;
+        border: none;
+        outline: none;
+        font-size: inherit;
+        font-weight: inherit;
+        font-family: inherit;
+        line-height: 1;
+      }
+
+      input {
+        border: none;
+      }
+
     `}
   />
 );

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -6,6 +6,31 @@ module.exports = {
       colors: {
         electric: '#db00ff',
         ribbon: '#0047ff',
+        primary: '#676FC6',
+        point: {
+          blue: '#537FEE',
+          red: '#FF451A',
+          yellow: '#F8AC19',
+          lilac: '#C2C5E8',
+        },
+        fontColor: {
+          redLabel: 'EE5353',
+          gray01: '#333',
+          gray02: '#4D4D4D',
+          gray03: '#666',
+          gray04: '#808080',
+          gray05: '#999',
+          gray06: '#B3B3B3',
+          gray07: '#CCC',
+          gray08: '#E6E6E6',
+          gray09: '#F6F6F6',
+        },
+        line: {
+          gray: '#E6E6E6',
+        },
+      },
+      borderRadius: {
+        default: '0.625rem' /* 10px */,
       },
     },
   },


### PR DESCRIPTION
# 공통 스타일 지정 및 input design

![Jul-04-2023 14-23-30](https://github.com/codestates-seb/seb44_main_016/assets/121333344/00e6a426-afe0-4efe-989f-240133682df3)


<br/>

## 구현한 기능
1. Global Style 지정
    - font-family 지정
    - 기본 style reset
3. tailwind config 수정
   - fontColor, pointColor, borderColor, primary 지정
4. input design 
   - 라디오, input-text, textarea, submit button 

<br/>

## 사용법

사용하고 싶은 곳에서 S-dot 컨벤션으로 CommonStyles를 불러옵니다.

```ts
const S = {
 ... CommonStyles,
}
```

사용할 부분에서 해당 디자인 컴포넌트를 불러옵니다.

```ts
 /*props로 회원가입 등 길게 쓸 때는 large, 팔로우 버튼에는 small, 글쓰기 버튼은 default 상태로 유지*/
  <S.SubmitBtn>로그인</S.SubmitBtn>
  <S.SubmitBtn large>로그인</S.SubmitBtn>
  <S.SubmitBtn small>팔로우</S.SubmitBtn>

/*input */
  <S.InputText type='text' placeholder='아이디'/>
  <S.Textarea placeholder='내용을 입력해주세요'></S.Textarea>

/*라디오버튼은 RadioBtnLabel이 RadioBtn을 감싸고 있는 구조입니다.*/
  <S.RadioBtnLabel>
    <S.RadioBtn type='radio' name='example' />
    옵션1
  </S.RadioBtnLabel>
  <S.RadioBtnLabel>
    <S.RadioBtn type='radio' name='example' />
    옵션2
  </S.RadioBtnLabel>
  <S.RadioBtnLabel>
    <S.RadioBtn type='radio' name='example' />
    옵션2
  </S.RadioBtnLabel>

```
