### PR TITLE
[FE] style-65 feat : 공통 레이아웃 설정

### DIFF
--- a/client/src/components/common/PageTemplate.tsx
+++ b/client/src/components/common/PageTemplate.tsx
@@ -1,5 +1,0 @@
-import tw from 'twin.macro';
-
-export const FlexPage = tw.div`
-w-full h-full
-`;

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -2,6 +2,8 @@ import type { AppProps } from 'next/app';
 import GlobalStyles from '../styles/GlobalStyles';
 
 import tw from 'twin.macro';
+import { useRouter } from 'next/router';
+import styled from '@emotion/styled';
 
 const RootScreen = tw.div`
 flex justify-center w-[100vw] min-h-[100vh]
@@ -11,16 +13,43 @@ const AppContainer = tw.div`
 max-w-[1140px] w-full
 `;
 
-const App = ({ Component, pageProps }: AppProps) => (
-  <>
-    {/*모든 ReactDOM에 margin: 0; padding: 0; box-sizing: border-box; 적용 */}
-    <GlobalStyles />
-    <RootScreen>
-      <AppContainer>
-        <Component {...pageProps} />
-      </AppContainer>
-    </RootScreen>
-  </>
-);
+const AsideFrame = tw.aside`
+w-[367px] h-full bg-pink-300
+`;
+
+const App = ({ Component, pageProps }: AppProps) => {
+  const router = useRouter();
+
+  let showNav = true;
+  let bgColor = '#F0F3F8';
+  if (router.pathname.startsWith('/user')) {
+    showNav = false;
+    if (router.pathname.startsWith('/user/signup')) {
+      bgColor = '#FFF';
+    }
+  }
+
+  return (
+    <>
+      {/*모든 ReactDOM에 margin: 0; padding: 0; box-sizing: border-box; 적용 */}
+      <GlobalStyles />
+      <RootScreen>
+        <AppContainer>
+          <S.FlexPage bgColor={bgColor}>
+            {showNav && <AsideFrame>sidenav 영역</AsideFrame>}
+            <Component {...pageProps} />
+          </S.FlexPage>
+        </AppContainer>
+      </RootScreen>
+    </>
+  );
+};
 
 export default App;
+
+const S = {
+  FlexPage: styled.div<{ bgColor?: string }>`
+    ${tw`flex w-full h-full`}
+    ${(props) => props.bgColor && `background-color: ${props.bgColor};`}
+  `,
+};

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,16 +1,5 @@
 import tw from 'twin.macro';
-import { FlexPage } from '../components/common/PageTemplate';
-
-const HomePageContainer = tw(FlexPage)`
-flex flex-col justify-center bg-[#F0F3F8]
-`;
 
 export default function HomePage() {
-  return (
-    <HomePageContainer>
-      <button>Submit</button>
-      <button>Submit</button>
-      <button>Submit</button>
-    </HomePageContainer>
-  );
+  return <button>Submit</button>;
 }

--- a/client/src/pages/test/test1/index.tsx
+++ b/client/src/pages/test/test1/index.tsx
@@ -1,0 +1,3 @@
+export default function index() {
+  return <div>테스트1</div>;
+}


### PR DESCRIPTION
# 공통 레이아웃 설정

![image](https://github.com/codestates-seb/seb44_main_016/assets/121333344/339fd6c4-a13c-4a78-a3a7-c18581c2344d)


<br/>

## 구현한 기능
1. flexpage app.tsx로 이동
    - URI 경로에 따라 배경 색상 변경
    - URI 경로에 따라 sidenav on,off 처리

<br/>

## 사용법

경로 `src/pages/_app.tsx`에서 해당 부분에 필요한 경로를 추가한다

```ts
let showNav = true;
  let bgColor = '#F0F3F8';
  if (router.pathname.startsWith('/user')) {
    showNav = false;
    if (router.pathname.startsWith('/user/signup')) {
      bgColor = '#FFF';
    }
  }

```

## 추후 수정 필요한 부분
- 경로 상수화
- 분기처리 많아질 시 switch 문으로 변경 