### PR TITLE
[FE] article-11: `<SnsArticle>` 더미 데이터 객체를 이용한 피드 게시글 디자인 구현

### DIFF
--- a/client/src/components/common/SnsArticle.tsx
+++ b/client/src/components/common/SnsArticle.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'react'; // useState 사용
 
 import tw from 'twin.macro';
 import styled from '@emotion/styled';
@@ -8,10 +8,22 @@ import Comment from './snsarticle/Comment';
 
 const S = {
   ...CommonStyles,
-  ArticleHeader: styled.section(
-    tw`w-full h-[58px] flex items-center justify-between px-[20px] `
+  /* 거대한 틀 */
+  SnsArticleContainer: styled.article(tw`w-[713px] flex flex-col items-end`),
+  LabelTemplate: styled.section(
+    tw`w-[116px] h-[37px] bg-white shadow-md font-bold 
+    rounded-t-[5px]  border-0 border-solid border-t-[3px] 
+    flex items-center justify-center`
   ),
-  /* ArticleHeader 내부 컴포넌트 */
+  Box: styled.section(
+    tw`w-full bg-white shadow-md
+    rounded-tl-default rounded-bl-default rounded-br-default`
+  ),
+
+  ArticleHeader: styled.section(
+    tw`w-full h-[58px] flex items-center justify-between px-[20px]`
+  ),
+  /* ↓ ArticleHeader 내부 컴포넌트 ↓ */
   Profile: styled.section(tw`flex justify-center gap-[10px]`),
   Nickname: styled.button(tw`font-bold`),
   ProfileImgButton: styled.button(
@@ -22,14 +34,25 @@ const S = {
   ImgContainer: styled.section(tw`w-full h-[328px] bg-pink-500`),
 
   ArtileMain: styled.section(tw`w-full p-[20px]  flex flex-col gap-[20px]`),
-  /* ArtileMain 내부 컴포넌트 */
+  /* ↓ ArtileMain 내부 컴포넌트 ↓ */
+  OtherButtonsContainer: styled.section(tw`w-full flex justify-end gap-[10px]`),
   VoteForm: styled.form(
     tw`w-full flex justify-center items-center gap-[10px] mt-[10px]`
   ),
-  OtherButtonsContainer: styled.section(tw`w-full flex justify-end gap-[10px]`),
+  /* ↓ VoteForm(절약 & Flex) 내부 컴포넌트 ↓ */
   SavingRateCount: styled.span(tw`text-point-blue font-bold`),
   FlexRateCount: styled.span(tw`text-point-red`),
-  /** 댓글 관련 **/
+  SavingBtn:
+    styled.button(tw`w-[90px] h-[40px] bg-point-blue rounded-full text-white
+    border-point-blue border-solid border-[3px]
+    hover:(bg-white text-point-blue font-bold)
+  `),
+  FlexBtn:
+    styled.button(tw`w-[90px] h-[40px] bg-point-red rounded-full text-white
+    border-point-red border-solid border-[3px]
+    hover:(bg-white text-point-red font-bold)
+  `),
+  /* ↓ 댓글 관련 ↓ */
   CommentsContainer: styled.section(tw``),
   CommentsDropdownButton: styled.button(
     tw`w-full h-[35px] bg-[#F6F6F6] text-left rounded-[50px] px-[20px]`
@@ -38,33 +61,7 @@ const S = {
   CommentForm: styled.form(tw`mt-[20px]`),
 };
 
-const SnsArticleContainer = tw.article`
-w-[713px]
-flex flex-col items-end
-`;
-
-const LabelTemplate = tw.section`
-w-[116px] h-[37px] bg-white shadow-md font-bold 
-rounded-t-[5px]  border-0 border-solid border-t-[3px] 
-flex items-center justify-center
-`;
-
-const Box = tw.section`
-w-full bg-white shadow-md
-rounded-tl-default rounded-bl-default rounded-br-default
-`;
-
-const SavingBtn = tw.button`
-w-[90px] h-[40px] bg-point-blue rounded-full text-white
- border-point-blue border-solid border-[3px]
-hover:(bg-white text-point-blue font-bold)
-`;
-const FlexBtn = tw.button`
-w-[90px] h-[40px] bg-point-red rounded-full text-white
- border-point-red border-solid border-[3px]
-hover:(bg-white text-point-red font-bold)
-`;
-
+/* Util 함수는 추후 다른 파일로 분리하고 Import할 예정 */
 function getKoreanDate(date: Date) {
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
@@ -76,6 +73,7 @@ function getKoreanDate(date: Date) {
   return formattedDate;
 }
 
+/* type은 추후 다른 파일로 분리하고 Import할 예정 */
 type Props = {
   data: {
     feedArticleId: number;
@@ -96,17 +94,17 @@ export default function EditorPage({ data }: Props) {
   const labelText = data.feedType === 1 ? '절약 팁' : '허락해줘!';
   const Label =
     data.feedType === 1
-      ? tw(LabelTemplate)`text-point-blue border-point-blue`
-      : tw(LabelTemplate)`text-point-yellow border-point-yellow`;
+      ? tw(S.LabelTemplate)`text-point-blue border-point-blue`
+      : tw(S.LabelTemplate)`text-point-yellow border-point-yellow`;
 
   const handleChangeOpenedOrClosed = () => {
     setIsCommentsOpened((prevBool) => !prevBool);
   };
 
   return (
-    <SnsArticleContainer>
+    <S.SnsArticleContainer>
       <Label>{labelText}</Label>
-      <Box>
+      <S.Box>
         <S.ArticleHeader>
           <S.Profile>
             <S.ProfileImgButton>
@@ -121,8 +119,8 @@ export default function EditorPage({ data }: Props) {
           <p>{data.content}</p>
           <S.VoteForm>
             <S.SavingRateCount>256</S.SavingRateCount>
-            <SavingBtn>👍절약</SavingBtn>
-            <FlexBtn>💸Flex</FlexBtn>
+            <S.SavingBtn>👍절약</S.SavingBtn>
+            <S.FlexBtn>💸Flex</S.FlexBtn>
             <S.FlexRateCount>48</S.FlexRateCount>
           </S.VoteForm>
           <S.OtherButtonsContainer>
@@ -149,7 +147,7 @@ export default function EditorPage({ data }: Props) {
             </S.CommentForm>
           </S.CommentsContainer>
         </S.ArtileMain>
-      </Box>
-    </SnsArticleContainer>
+      </S.Box>
+    </S.SnsArticleContainer>
   );
 }

--- a/client/src/components/common/SnsArticle.tsx
+++ b/client/src/components/common/SnsArticle.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import tw from 'twin.macro';
+import styled from '@emotion/styled';
+
+import CommonStyles from '../../styles/CommonStyles';
+import Comment from './snsarticle/Comment';
+
+const S = {
+  ...CommonStyles,
+  ArticleHeader: styled.section(
+    tw`w-full h-[58px] flex items-center justify-between px-[20px] `
+  ),
+  /* ArticleHeader 내부 컴포넌트 */
+  Profile: styled.section(tw`flex justify-center gap-[10px]`),
+  Nickname: styled.button(tw`font-bold`),
+  ProfileImgButton: styled.button(
+    tw`w-[40px] h-[40px] rounded-[50px] overflow-hidden shrink-0`
+  ),
+  ProfileImg: styled.img(tw`w-full h-full bg-black `),
+  CreatedAt: styled.section(tw``),
+  ImgContainer: styled.section(tw`w-full h-[328px] bg-pink-500`),
+
+  ArtileMain: styled.section(tw`w-full p-[20px]  flex flex-col gap-[20px]`),
+  /* ArtileMain 내부 컴포넌트 */
+  VoteForm: styled.form(tw`w-full flex justify-center items-center gap-[10px]`),
+  OtherButtonsContainer: styled.section(tw`w-full flex justify-end gap-[10px]`),
+  /** 댓글 관련 **/
+  CommentsContainer: styled.section(tw``),
+  CommentsDropdownButton: styled.button(
+    tw`w-full h-[35px] bg-[#F6F6F6] text-left rounded-[50px] px-[20px]`
+  ),
+  CommentList: styled.ol(tw`flex flex-col`),
+  CommentForm: styled.form(tw`mt-[20px]`),
+};
+
+const SnsArticleContainer = tw.article`
+w-[713px]
+flex flex-col items-end
+`;
+
+const Label = tw.section`
+w-[116px] h-[37px] bg-white shadow-md font-bold text-[#537FEE]
+rounded-t-[5px]  border-0 border-solid border-t-[3px] border-[#537FEE]
+flex items-center justify-center
+`;
+
+const Box = tw.section`
+w-full bg-white shadow-md
+rounded-tl-[10px] rounded-bl-[10px] rounded-br-[10px]
+`;
+
+export default function EditorPage() {
+  return (
+    <SnsArticleContainer>
+      <Label>절약 팁</Label>
+      <Box>
+        <S.ArticleHeader>
+          <S.Profile>
+            <S.ProfileImgButton>
+              <S.ProfileImg />
+            </S.ProfileImgButton>
+            <S.Nickname>Waypil</S.Nickname>
+          </S.Profile>
+          <S.CreatedAt>2023년 6월 30일</S.CreatedAt>
+        </S.ArticleHeader>
+        <S.ImgContainer></S.ImgContainer>
+        <S.ArtileMain>
+          <p>
+            본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문
+          </p>
+          <S.VoteForm>
+            <span>256</span>
+            <button>👍절약</button>
+            <button>💸Flex</button>
+            <span>48</span>
+          </S.VoteForm>
+          <S.OtherButtonsContainer>
+            <button>수정</button>
+            <button>삭제</button>
+          </S.OtherButtonsContainer>
+          <S.CommentsContainer>
+            <S.CommentsDropdownButton>
+              댓글 12개 모두 보기
+            </S.CommentsDropdownButton>
+            <S.CommentList>
+              <Comment>다람쥐 헌 쳇바퀴에 타고파.</Comment>
+              <Comment>
+                댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글
+                댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글
+              </Comment>
+            </S.CommentList>
+            <S.CommentForm>
+              <S.InputText placeholder='댓글을 입력하세요'></S.InputText>
+            </S.CommentForm>
+          </S.CommentsContainer>
+        </S.ArtileMain>
+      </Box>
+    </SnsArticleContainer>
+  );
+}

--- a/client/src/components/common/SnsArticle.tsx
+++ b/client/src/components/common/SnsArticle.tsx
@@ -6,61 +6,6 @@ import styled from '@emotion/styled';
 import CommonStyles from '../../styles/CommonStyles';
 import Comment from './snsarticle/Comment';
 
-const S = {
-  ...CommonStyles,
-  /* 거대한 틀 */
-  SnsArticleContainer: styled.article(tw`w-[713px] flex flex-col items-end`),
-  LabelTemplate: styled.section(
-    tw`w-[116px] h-[37px] bg-white shadow-md font-bold 
-    rounded-t-[5px]  border-0 border-solid border-t-[3px] 
-    flex items-center justify-center`
-  ),
-  Box: styled.section(
-    tw`w-full bg-white shadow-md
-    rounded-tl-default rounded-bl-default rounded-br-default`
-  ),
-
-  ArticleHeader: styled.section(
-    tw`w-full h-[58px] flex items-center justify-between px-[20px]`
-  ),
-  /* ↓ ArticleHeader 내부 컴포넌트 ↓ */
-  Profile: styled.section(tw`flex justify-center gap-[10px]`),
-  Nickname: styled.button(tw`font-bold`),
-  ProfileImgButton: styled.button(
-    tw`w-[40px] h-[40px] rounded-full overflow-hidden shrink-0`
-  ),
-  ProfileImg: styled.img(tw`w-full h-full bg-black `),
-  CreatedAt: styled.section(tw``),
-  ImgContainer: styled.section(tw`w-full h-[328px] bg-pink-500`),
-
-  ArtileMain: styled.section(tw`w-full p-[20px]  flex flex-col gap-[20px]`),
-  /* ↓ ArtileMain 내부 컴포넌트 ↓ */
-  OtherButtonsContainer: styled.section(tw`w-full flex justify-end gap-[10px]`),
-  VoteForm: styled.form(
-    tw`w-full flex justify-center items-center gap-[10px] mt-[10px]`
-  ),
-  /* ↓ VoteForm(절약 & Flex) 내부 컴포넌트 ↓ */
-  SavingRateCount: styled.span(tw`text-point-blue font-bold`),
-  FlexRateCount: styled.span(tw`text-point-red`),
-  SavingBtn:
-    styled.button(tw`w-[90px] h-[40px] bg-point-blue rounded-full text-white
-    border-point-blue border-solid border-[3px]
-    hover:(bg-white text-point-blue font-bold)
-  `),
-  FlexBtn:
-    styled.button(tw`w-[90px] h-[40px] bg-point-red rounded-full text-white
-    border-point-red border-solid border-[3px]
-    hover:(bg-white text-point-red font-bold)
-  `),
-  /* ↓ 댓글 관련 ↓ */
-  CommentsContainer: styled.section(tw``),
-  CommentsDropdownButton: styled.button(
-    tw`w-full h-[35px] bg-[#F6F6F6] text-left rounded-[50px] px-[20px]`
-  ),
-  CommentList: styled.ol(tw`flex flex-col`),
-  CommentForm: styled.form(tw`mt-[20px]`),
-};
-
 /* Util 함수는 추후 다른 파일로 분리하고 Import할 예정 */
 function getKoreanDate(date: Date) {
   const year = date.getFullYear();
@@ -151,3 +96,58 @@ export default function EditorPage({ data }: Props) {
     </S.SnsArticleContainer>
   );
 }
+
+const S = {
+  ...CommonStyles,
+  /* 거대한 틀 */
+  SnsArticleContainer: styled.article(tw`w-[713px] flex flex-col items-end`),
+  LabelTemplate: styled.section(
+    tw`w-[116px] h-[37px] bg-white shadow-md font-bold 
+    rounded-t-[5px]  border-0 border-solid border-t-[3px] 
+    flex items-center justify-center`
+  ),
+  Box: styled.section(
+    tw`w-full bg-white shadow-md
+    rounded-tl-default rounded-bl-default rounded-br-default`
+  ),
+
+  ArticleHeader: styled.section(
+    tw`w-full h-[58px] flex items-center justify-between px-[20px]`
+  ),
+  /* ↓ ArticleHeader 내부 컴포넌트 ↓ */
+  Profile: styled.section(tw`flex justify-center gap-[10px]`),
+  Nickname: styled.button(tw`font-bold`),
+  ProfileImgButton: styled.button(
+    tw`w-[40px] h-[40px] rounded-full overflow-hidden shrink-0`
+  ),
+  ProfileImg: styled.img(tw`w-full h-full bg-black `),
+  CreatedAt: styled.section(tw``),
+  ImgContainer: styled.section(tw`w-full h-[328px] bg-pink-500`),
+
+  ArtileMain: styled.section(tw`w-full p-[20px]  flex flex-col gap-[20px]`),
+  /* ↓ ArtileMain 내부 컴포넌트 ↓ */
+  OtherButtonsContainer: styled.section(tw`w-full flex justify-end gap-[10px]`),
+  VoteForm: styled.form(
+    tw`w-full flex justify-center items-center gap-[10px] mt-[10px]`
+  ),
+  /* ↓ VoteForm(절약 & Flex) 내부 컴포넌트 ↓ */
+  SavingRateCount: styled.span(tw`text-point-blue font-bold`),
+  FlexRateCount: styled.span(tw`text-point-red`),
+  SavingBtn:
+    styled.button(tw`w-[90px] h-[40px] bg-point-blue rounded-full text-white
+    border-point-blue border-solid border-[3px]
+    hover:(bg-white text-point-blue font-bold)
+  `),
+  FlexBtn:
+    styled.button(tw`w-[90px] h-[40px] bg-point-red rounded-full text-white
+    border-point-red border-solid border-[3px]
+    hover:(bg-white text-point-red font-bold)
+  `),
+  /* ↓ 댓글 관련 ↓ */
+  CommentsContainer: styled.section(tw``),
+  CommentsDropdownButton: styled.button(
+    tw`w-full h-[35px] bg-[#F6F6F6] text-left rounded-[50px] px-[20px]`
+  ),
+  CommentList: styled.ol(tw`flex flex-col`),
+  CommentForm: styled.form(tw`mt-[20px]`),
+};

--- a/client/src/components/common/SnsArticle.tsx
+++ b/client/src/components/common/SnsArticle.tsx
@@ -15,7 +15,7 @@ const S = {
   Profile: styled.section(tw`flex justify-center gap-[10px]`),
   Nickname: styled.button(tw`font-bold`),
   ProfileImgButton: styled.button(
-    tw`w-[40px] h-[40px] rounded-[50px] overflow-hidden shrink-0`
+    tw`w-[40px] h-[40px] rounded-full overflow-hidden shrink-0`
   ),
   ProfileImg: styled.img(tw`w-full h-full bg-black `),
   CreatedAt: styled.section(tw``),
@@ -23,8 +23,12 @@ const S = {
 
   ArtileMain: styled.section(tw`w-full p-[20px]  flex flex-col gap-[20px]`),
   /* ArtileMain 내부 컴포넌트 */
-  VoteForm: styled.form(tw`w-full flex justify-center items-center gap-[10px]`),
+  VoteForm: styled.form(
+    tw`w-full flex justify-center items-center gap-[10px] mt-[10px]`
+  ),
   OtherButtonsContainer: styled.section(tw`w-full flex justify-end gap-[10px]`),
+  SavingRateCount: styled.span(tw`text-point-blue font-bold`),
+  FlexRateCount: styled.span(tw`text-point-red`),
   /** 댓글 관련 **/
   CommentsContainer: styled.section(tw``),
   CommentsDropdownButton: styled.button(
@@ -39,21 +43,69 @@ w-[713px]
 flex flex-col items-end
 `;
 
-const Label = tw.section`
-w-[116px] h-[37px] bg-white shadow-md font-bold text-[#537FEE]
-rounded-t-[5px]  border-0 border-solid border-t-[3px] border-[#537FEE]
+const LabelTemplate = tw.section`
+w-[116px] h-[37px] bg-white shadow-md font-bold 
+rounded-t-[5px]  border-0 border-solid border-t-[3px] 
 flex items-center justify-center
 `;
 
 const Box = tw.section`
 w-full bg-white shadow-md
-rounded-tl-[10px] rounded-bl-[10px] rounded-br-[10px]
+rounded-tl-default rounded-bl-default rounded-br-default
 `;
 
-export default function EditorPage() {
+const SavingBtn = tw.button`
+w-[90px] h-[40px] bg-point-blue rounded-full text-white
+ border-point-blue border-solid border-[3px]
+hover:(bg-white text-point-blue font-bold)
+`;
+const FlexBtn = tw.button`
+w-[90px] h-[40px] bg-point-red rounded-full text-white
+ border-point-red border-solid border-[3px]
+hover:(bg-white text-point-red font-bold)
+`;
+
+function getKoreanDate(date: Date) {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = date.getHours().toString().padStart(2, '0'); // 한 자릿수라면 앞에 0 추가
+  const minutes = date.getMinutes().toString().padStart(2, '0'); // 한 자릿수라면 앞에 0 추가
+
+  const formattedDate = `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
+  return formattedDate;
+}
+
+type Props = {
+  data: {
+    feedArticleId: number;
+    feedType: number; // 사용
+    content: string; // 사용
+    createdAt: Date; // 사용
+    modifiedAt: Date;
+    imageId: number;
+    userId: number;
+    voteId: number;
+    feedArticleHashtagId: number;
+  };
+};
+
+export default function EditorPage({ data }: Props) {
+  const [isCommentsOpened, setIsCommentsOpened] = React.useState(false);
+
+  const labelText = data.feedType === 1 ? '절약 팁' : '허락해줘!';
+  const Label =
+    data.feedType === 1
+      ? tw(LabelTemplate)`text-point-blue border-point-blue`
+      : tw(LabelTemplate)`text-point-yellow border-point-yellow`;
+
+  const handleChangeOpenedOrClosed = () => {
+    setIsCommentsOpened((prevBool) => !prevBool);
+  };
+
   return (
     <SnsArticleContainer>
-      <Label>절약 팁</Label>
+      <Label>{labelText}</Label>
       <Box>
         <S.ArticleHeader>
           <S.Profile>
@@ -62,34 +114,36 @@ export default function EditorPage() {
             </S.ProfileImgButton>
             <S.Nickname>Waypil</S.Nickname>
           </S.Profile>
-          <S.CreatedAt>2023년 6월 30일</S.CreatedAt>
+          <S.CreatedAt>{getKoreanDate(data.createdAt)}</S.CreatedAt>
         </S.ArticleHeader>
         <S.ImgContainer></S.ImgContainer>
         <S.ArtileMain>
-          <p>
-            본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문본문
-          </p>
+          <p>{data.content}</p>
           <S.VoteForm>
-            <span>256</span>
-            <button>👍절약</button>
-            <button>💸Flex</button>
-            <span>48</span>
+            <S.SavingRateCount>256</S.SavingRateCount>
+            <SavingBtn>👍절약</SavingBtn>
+            <FlexBtn>💸Flex</FlexBtn>
+            <S.FlexRateCount>48</S.FlexRateCount>
           </S.VoteForm>
           <S.OtherButtonsContainer>
             <button>수정</button>
             <button>삭제</button>
           </S.OtherButtonsContainer>
           <S.CommentsContainer>
-            <S.CommentsDropdownButton>
+            <S.CommentsDropdownButton onClick={handleChangeOpenedOrClosed}>
               댓글 12개 모두 보기
             </S.CommentsDropdownButton>
-            <S.CommentList>
-              <Comment>다람쥐 헌 쳇바퀴에 타고파.</Comment>
-              <Comment>
-                댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글
-                댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글
-              </Comment>
-            </S.CommentList>
+            {isCommentsOpened ? (
+              <S.CommentList>
+                <Comment>다람쥐 헌 쳇바퀴에 타고파.</Comment>
+                <Comment>
+                  댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글
+                  댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글댓글
+                </Comment>
+              </S.CommentList>
+            ) : (
+              <></>
+            )}
             <S.CommentForm>
               <S.InputText placeholder='댓글을 입력하세요'></S.InputText>
             </S.CommentForm>

--- a/client/src/components/common/snsarticle/Comment.tsx
+++ b/client/src/components/common/snsarticle/Comment.tsx
@@ -14,7 +14,7 @@ const S = {
   LikeButtonContainer: styled.section(tw` pl-[15px]`),
 
   ProfileImgButton: styled.button(
-    tw`w-[40px] h-[40px] rounded-[50px] overflow-hidden shrink-0`
+    tw`w-[40px] h-[40px] rounded-full overflow-hidden shrink-0`
   ),
   ProfileImg: styled.img(tw`w-full h-full bg-black `),
   Texts: styled.section(tw`flex flex-col gap-[10px]`),

--- a/client/src/components/common/snsarticle/Comment.tsx
+++ b/client/src/components/common/snsarticle/Comment.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import tw from 'twin.macro';
+import styled from '@emotion/styled';
+
+const S = {
+  CommentContainer: styled.li(
+    tw`w-full p-[20px]
+    border-0 border-solid border-b-[3px] border-gray-200
+    flex justify-between items-center `
+  ),
+  Left: styled.section(tw`flex gap-[10px]`),
+
+  LikeButtonContainer: styled.section(tw` pl-[15px]`),
+
+  ProfileImgButton: styled.button(
+    tw`w-[40px] h-[40px] rounded-[50px] overflow-hidden shrink-0`
+  ),
+  ProfileImg: styled.img(tw`w-full h-full bg-black `),
+  Texts: styled.section(tw`flex flex-col gap-[10px]`),
+
+  Upper: styled.p(tw`flex gap-[10px]`),
+  Nickname: styled.button(tw`font-bold mr-[10px]`),
+  CommentText: styled.span(tw``),
+
+  Lower: styled.p(tw`flex gap-[10px]`),
+  CreatedAt: styled.span(tw``),
+  LikeCount: styled.span(tw``),
+  AddReplyButton: styled.button(tw``),
+  ReportButton: styled.button(tw``),
+
+  LikeButton: styled.button(tw``),
+};
+// '더 보기' 버튼 구현 요망
+
+type Props = {
+  children?: string;
+};
+
+export default function CommentComponent(props: Props) {
+  return (
+    <S.CommentContainer>
+      <S.Left>
+        <S.ProfileImgButton>
+          <S.ProfileImg />
+        </S.ProfileImgButton>
+        <S.Texts>
+          <S.Upper>
+            <S.CommentText>
+              <S.Nickname>waypil</S.Nickname>
+              <span>{props.children}</span>
+            </S.CommentText>
+          </S.Upper>
+          <S.Lower>
+            <S.CreatedAt>1주</S.CreatedAt>
+            <S.LikeCount>좋아요 805개</S.LikeCount>
+            <S.AddReplyButton>답글 달기</S.AddReplyButton>
+            <S.ReportButton>신고</S.ReportButton>
+          </S.Lower>
+        </S.Texts>
+      </S.Left>
+      <S.LikeButtonContainer>
+        <S.LikeButton>♡</S.LikeButton>
+      </S.LikeButtonContainer>
+    </S.CommentContainer>
+  );
+}

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 
 const RootScreen = tw.div`
-flex justify-center w-[100vw] min-h-[100vh]
+flex justify-center w-[100%] min-h-[100vh]
 `;
 
 const AppContainer = tw.div`

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -7,14 +7,37 @@ const HomePageContainer = tw.div`
 w-full flex flex-col items-center p-[30px] gap-[30px]
 `;
 
+const feedArticleDummyA = {
+  feedArticleId: 1,
+  feedType: 1, // 절약 팁 enum
+  content:
+    '절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁! 절약 팁!',
+  createdAt: new Date(),
+  modifiedAt: new Date(),
+  imageId: 0,
+  userId: 0,
+  voteId: 0,
+  feedArticleHashtagId: 0,
+};
+
+const feedArticleDummyB = {
+  feedArticleId: 2,
+  feedType: 2, // 허락해줘! enum
+  content:
+    '허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘! 허락해줘!',
+  createdAt: new Date(),
+  modifiedAt: new Date(),
+  imageId: 0,
+  userId: 0,
+  voteId: 0,
+  feedArticleHashtagId: 0,
+};
+
 export default function HomePage() {
   return (
     <HomePageContainer>
-      <SnsArticle></SnsArticle>
-      <SnsArticle></SnsArticle>
-      <SnsArticle></SnsArticle>
-      <SnsArticle></SnsArticle>
-      <SnsArticle></SnsArticle>
+      <SnsArticle data={feedArticleDummyA}></SnsArticle>
+      <SnsArticle data={feedArticleDummyB}></SnsArticle>
     </HomePageContainer>
   );
 }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,5 +1,20 @@
+import React from 'react';
+
 import tw from 'twin.macro';
+import SnsArticle from '../components/common/SnsArticle';
+
+const HomePageContainer = tw.div`
+w-full flex flex-col items-center p-[30px] gap-[30px]
+`;
 
 export default function HomePage() {
-  return <button>Submit</button>;
+  return (
+    <HomePageContainer>
+      <SnsArticle></SnsArticle>
+      <SnsArticle></SnsArticle>
+      <SnsArticle></SnsArticle>
+      <SnsArticle></SnsArticle>
+      <SnsArticle></SnsArticle>
+    </HomePageContainer>
+  );
 }


### PR DESCRIPTION
![image](https://github.com/codestates-seb/seb44_main_016/assets/65957855/afad0644-4a15-43b0-9c0a-b704e8c6afd3)

## 구현한 기능
* `<SnsArticle>`에 더미 데이터 객체를 할당하여 디자인 구현. (서버와의 통신 대비)
* `댓글 nn개 모두 보기` 클릭 시 댓글란 접고 펼치기 가능.
* 기타 디자인 개선

## 버그 수정
* x축+y축에 불필요한 스크롤바가 나타나는 버그 수정 `w-[100vw]` → `w-[100%]`

## 추후 개선점
* 댓글 `더 보기` 버튼
* `<RankLabel>` 구현
* 유저명/프사 클릭 → 해당 유저 페이지로
* #86 
* 절약/Flex 버튼 클릭 시 수치 ±1
* 삭제 버튼 : 클릭 → 경고 메시지 → {삭제}
* 수정 버튼 : 클릭 → 게시글 편집 페이지로
* 이미지 관련 기능 (이미지 실제로 적용 & 이미지 슬라이드 기능 등등)

<br/>

## 비고
아직 미완성이긴 하나, **우선 순위가 높은 다음 작업**으로 빨리 이동하기 위한 조기 PR입니다.