### PR TITLE
[FE] Style-80 tailwind-css에서 emotion-css로 변경 

### DIFF
--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -1,21 +1,7 @@
 import type { AppProps } from 'next/app';
 import GlobalStyles from '../styles/GlobalStyles';
-
-import tw from 'twin.macro';
 import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
-
-const RootScreen = tw.div`
-flex justify-center w-[100vw] min-h-[100vh]
-`;
-
-const AppContainer = tw.div`
-max-w-[1140px] w-full
-`;
-
-const AsideFrame = tw.aside`
-w-[367px] h-full bg-pink-300
-`;
 
 const App = ({ Component, pageProps }: AppProps) => {
   const router = useRouter();
@@ -33,14 +19,14 @@ const App = ({ Component, pageProps }: AppProps) => {
     <>
       {/*모든 ReactDOM에 margin: 0; padding: 0; box-sizing: border-box; 적용 */}
       <GlobalStyles />
-      <RootScreen>
-        <AppContainer>
+      <S.RootScreen>
+        <S.AppContainer>
           <S.FlexPage bgColor={bgColor}>
-            {showNav && <AsideFrame>sidenav 영역</AsideFrame>}
+            {showNav && <S.AsideFrame>sidenav 영역</S.AsideFrame>}
             <Component {...pageProps} />
           </S.FlexPage>
-        </AppContainer>
-      </RootScreen>
+        </S.AppContainer>
+      </S.RootScreen>
     </>
   );
 };
@@ -48,8 +34,29 @@ const App = ({ Component, pageProps }: AppProps) => {
 export default App;
 
 const S = {
+  RootScreen: styled.div`
+    display: flex;
+    justify-content: center;
+    width: 100vw;
+    min-height: 100vh;
+  `,
+
+  AppContainer: styled.div`
+    max-width: 1140px;
+    width: 100%;
+    display: flex;
+  `,
+
+  AsideFrame: styled.aside`
+    width: 367px;
+    height: 100%;
+    background-color: #f6ccd9;
+  `,
+
   FlexPage: styled.div<{ bgColor?: string }>`
-    ${tw`flex w-full h-full`}
-    ${(props) => props.bgColor && `background-color: ${props.bgColor};`}
+    display: flex;
+    width: 100%;
+    height: 100%;
+    background-color: ${(props) => props.bgColor || 'transparent'};
   `,
 };

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,5 +1,3 @@
-import tw from 'twin.macro';
-
 export default function HomePage() {
   return <button>Submit</button>;
 }

--- a/client/src/styles/CommonStyles.tsx
+++ b/client/src/styles/CommonStyles.tsx
@@ -1,40 +1,138 @@
 import styled from '@emotion/styled';
-import { InputHTMLAttributes } from 'react';
-import tw from 'twin.macro';
 
 interface ButtonProps {
   small?: boolean;
   large?: boolean;
 }
 
-type InputProps = InputHTMLAttributes<HTMLInputElement>;
-
 const CommonStyles = {
-  SubmitBtn: styled.button<ButtonProps>((props) => [
-    tw`relative inline-block text-white p-4 rounded-full font-normal border-2 border-primary border-solid overflow-hidden bg-white z-10 hover:(text-primary bg-white duration-700 font-bold) before:(content-[''] absolute w-80 h-80 -left-16 -top-16 -z-10 rounded-full bg-primary translate-x-full translate-y-full transition-all duration-700) before:hover:( top-10 left-10 transition-all duration-700)`,
-    props.small
-      ? tw`w-auto px-[1.125rem] py-[0.68rem] before:(w-32 h-32 -left-1/2 -top-1/2) before:hover:(top-16 left-10)`
-      : props.large
-      ? tw`w-full max-w-xl before:(w-[1000px] h-[1000px] -left-1/2 -top-[1000%]) before:hover:(top-16 left-10)`
-      : tw`w-40`,
-  ]),
+  SubmitBtn: styled.button<ButtonProps>`
+    position: relative;
+    display: inline-block;
+    color: var(--color-white);
+    padding: 1rem;
+    border-radius: 100px;
+    font-weight: 400;
+    border: 2px solid var(--color-primary);
+    overflow: hidden;
+    background-color: white;
+    z-index: 1;
 
-  InputText: styled.input<InputProps>`
-    ${tw`bg-white rounded-full w-full px-7 py-4 border-line-gray border border-solid text-fontColor-gray01 placeholder:text-fontColor-gray07 focus:outline-primary `}
+    &:hover {
+      color: var(--color-primary);
+      background-color: white;
+      transition-duration: 0.7s;
+      font-weight: 700;
+    }
+    &::before {
+      content: '';
+      position: absolute;
+      width: 20rem;
+      height: 20rem;
+      top: -4rem;
+      left: -4rem;
+      z-index: -1;
+      border-radius: 100%;
+      background: var(--color-primary);
+      transition: 0.7s;
+    }
+
+    &:hover::before {
+      top: 2.5rem;
+      left: 2.5rem;
+    }
+    ${({ small }) =>
+      small &&
+      `
+    width: auto;
+    padding: 0.68rem 1.125rem;
+    &::before {
+        width: 8rem;
+        height: 8rem;
+        top:-1.6rem;
+        left:-1.6rem;
+      }
+    &:hover::before{
+      top: 4rem;
+      left: 4rem;
+    }
+  `}
+
+    ${({ large }) =>
+      large &&
+      `
+    width: 100%;
+    max-width: 40rem;
+    &::before {
+        width: 80rem;
+        height: 80rem;
+        top:-16rem;
+        left:-16rem;
+      }
+
+      &:hover::before{
+        top: 10rem;
+        left: 10rem;
+      }
+  `}
+  
+  ${({ small, large }) =>
+      !small &&
+      !large &&
+      `
+    width: 10rem;
+  `}
   `,
-
-  Textarea: styled.textarea<React.HTMLProps<HTMLTextAreaElement>>`
-    ${tw`bg-white rounded-default w-full px-7 py-4 text-fontColor-gray01 placeholder:text-fontColor-gray07 border-line-gray resize-none min-h-[120px] focus:outline-primary`}
+  InputText: styled.input`
+    background-color: white;
+    border-radius: 100px;
+    width: 100%;
+    padding: 1rem;
+    color: var(--color-gray01);
+    border: 1px solid var(--color-border-gray);
+    &:placeholder {
+      color: var(--color-gray07);
+    }
+    &:focus {
+      outline: 1px solid var(--color-primary);
+    }
   `,
+  Textarea: styled.textarea`
+    background-color: white;
+    border-radius: 6px;
+    width: 100%;
+    padding: 1rem;
+    color: var(--color-gray01);
+    border: 1px solid var(--color-border-gray);
+    resize: none;
+    min-height: 120px;
 
-  RadioBtnLabel: tw.label`
-  flex align-middle font-normal
+    &:placeholder {
+      color: var(--color-gray07);
+    }
+    &:focus {
+      outline: 1px solid var(--color-primary);
+    }
   `,
+  RadioBtnLabel: styled.label`
+    display: flex;
+    align-items: center;
+    font-weight: 400;
+  `,
+  RadioBtn: styled.input`
+    appearance: none;
+    position: relative;
+    width: 18px;
+    height: 18px;
+    border: 1px solid var(--color-border-gray);
+    border-radius: 100%;
+    background-color: var(--color-white);
+    cursor: pointer;
+    margin-right: 10px;
 
-  RadioBtn: tw.input`
-  appearance-none relative w-[18px] h-[18px] border-line-gray rounded-full border border-solid bg-white cursor-pointer mr-[10px]
-
-  checked:( border-primary border-4)
+    &:checked {
+      border: 4px solid var(--color-primary);
+    }
   `,
 };
 

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -15,6 +15,34 @@ const GlobalStyles = () => (
         color: #333;
         font-family: 'Pretendard';
         font-weight: 400;
+
+
+        /* color */
+        --color-primary : #676FC6;
+        --color-point-red : #FF451A;
+        --color-point-blue : #537FEE;
+        --color-point-yellow : #F8AC19;
+        --color-point-lilac : #C2C5E8;
+        --color-white : #FFF;
+
+        --color-gray01 : #333;
+        --color-gray02 : #4D4D4D;
+        --color-gray03 : #666;
+        --color-gray04 : #808080;
+        --color-gray05 : #999;
+        --color-gray06 : #B3B3B3;
+        --color-gray07 : #CCC;
+        --color-gray08 : #E6E6E6;
+        --color-gray09 : #F6F6F6;
+
+        --color-border-gray : #E6E6E6
+
+        /* box-shadow */
+        --shadow-default : 0 1px 10px rgba(170,170,170,25);
+
+        /* border-radius */
+        --rounded-default: 0.625rem;
+
       }
 
       li {
@@ -72,6 +100,7 @@ const GlobalStyles = () => (
         border: none;
       }
 
+      
     `}
   />
 );

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -35,7 +35,7 @@ const GlobalStyles = () => (
         --color-gray08 : #E6E6E6;
         --color-gray09 : #F6F6F6;
 
-        --color-border-gray : #E6E6E6
+        --color-border-gray : #E6E6E6;
 
         /* box-shadow */
         --shadow-default : 0 1px 10px rgba(170,170,170,25);


### PR DESCRIPTION
# [FE] Style-80 tailwind-css에서 emotion-css로 변경 

스크린샷 생략합니다.

<br/>

## 구현한 기능
1. 기존에 사용하던 tailwind css가 익숙치 않아 작업이 늦어져 emotion으로 변경하였습니다.

<br/>

## 비고
