### PR TITLE
[FE] Hotfix: 불필요한 X축 스크롤바 버그 수정

### DIFF
--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -44,7 +44,7 @@ const S = {
   RootScreen: styled.div`
     display: flex;
     justify-content: center;
-    width: 100vw;
+    width: 100%;
     min-height: 100vh;
   `,
 


### PR DESCRIPTION
# [FE] Hotfix: 불필요한 X축 스크롤바 버그 수정

## 문제점
![화면 캡처 2023-07-06 003311](https://github.com/codestates-seb/seb44_main_016/assets/65957855/ff4448c4-c3da-4252-a368-8642ed7bd578)

화면의 가로 너비를 `100vw`라고 설정할 경우 저러한 버그가 발생합니다.

<br>

### 원인
`100vw`는 스크롤바의 너비를 포함한 수치입니다. 때문에 overflow-y로 인해 Y축 스크롤바가 생성될 때, Y축 스크롤바의 가로폭만큼 overflow-x가 발생하기 때문에 X축 스크롤바도 같이 생성되어버립니다.

<br>

### 해결책 및 수정 사항
화면의 가로 너비를 `100%`라고 지정함으로써 해당 버그를 고쳤습니다.

![image](https://github.com/codestates-seb/seb44_main_016/assets/65957855/e4aa75d1-42c2-4632-9578-b2c1b4a8bf69)