### PR TITLE
[FE]  `<Aside>` 및 `<Component {...pageProps}>` 버그 수정

### DIFF
--- a/client/src/components/Aside.tsx
+++ b/client/src/components/Aside.tsx
@@ -139,11 +139,12 @@ export default function Aside(props: Props) {
 const S = {
   ...CommonStyles,
   AsideContainer: styled.aside`
-    position: relative;
+    position: fixed;
     height: 100%;
     background-color: white;
     border-right: 1px solid var(--color-gray08);
     // border: 1px solid;
+    flex-shrink: 0;
     display: flex;
     align-items: flex-start;
   `,
@@ -160,7 +161,6 @@ const S = {
   `,
   Lower: styled.section`
     width: 100%;
-    flex-shrink: 0;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -12,10 +12,10 @@ const queryClient = new QueryClient();
 const App = ({ Component, pageProps }: AppProps) => {
   const router = useRouter();
 
-  let showNav = true;
+  let isShowNav = true;
   let bgColor = '#F0F3F8';
   if (router.pathname.startsWith('/user')) {
-    showNav = false;
+    isShowNav = false;
     if (router.pathname.startsWith('/user/signup')) {
       bgColor = '#FFF';
     }
@@ -29,8 +29,8 @@ const App = ({ Component, pageProps }: AppProps) => {
         <S.RootScreen>
           <S.AppContainer>
             <S.FlexPage>
-              {showNav && <Aside isLoggedIn={true} />}
-              <S.SubPage bgColor={bgColor}>
+              {isShowNav && <Aside isLoggedIn={true} />}
+              <S.SubPage isShowNav={isShowNav} bgColor={bgColor}>
                 <Component {...pageProps} />
               </S.SubPage>
             </S.FlexPage>
@@ -64,10 +64,11 @@ const S = {
     height: 100%;
   `,
 
-  SubPage: styled.div<{ bgColor?: string }>`
+  SubPage: styled.div<{ isShowNav: boolean; bgColor?: string }>`
     display: flex;
     width: 100%;
     height: 100%;
+    margin-left: ${(props) => props.isShowNav && '250px'}; // <Aside> width
     background-color: ${(props) => props.bgColor || 'transparent'};
   `,
 };

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -28,9 +28,11 @@ const App = ({ Component, pageProps }: AppProps) => {
         <GlobalStyles />
         <S.RootScreen>
           <S.AppContainer>
-            <S.FlexPage bgColor={bgColor}>
+            <S.FlexPage>
               {showNav && <Aside isLoggedIn={true} />}
-              <Component {...pageProps} />
+              <S.SubPage bgColor={bgColor}>
+                <Component {...pageProps} />
+              </S.SubPage>
             </S.FlexPage>
           </S.AppContainer>
         </S.RootScreen>
@@ -56,7 +58,13 @@ const S = {
     display: flex;
   `,
 
-  FlexPage: styled.div<{ bgColor?: string }>`
+  FlexPage: styled.div`
+    display: flex;
+    width: 100%;
+    height: 100%;
+  `,
+
+  SubPage: styled.div<{ bgColor?: string }>`
     display: flex;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
# 1차 문제점: fix-component-width: `<Component {...pageProps}>` width가 고정되지 않는 버그 수정

![화면 캡처 2023-07-06 223355](https://github.com/codestates-seb/seb44_main_016/assets/65957855/c40984d1-adc2-4279-8782-83f718c6ff81)

(해당 스샷 기준) 화면은 왼쪽 영역(`<Aside>`)과 오른쪽 영역으로 나눌 수 있다.

여기서 '오른쪽 영역'의 사이즈가 고정되지 않고 내용물에 따라서 계속 변한다는 버그 이슈가 들어왔다.

<br>

## 원인
결론부터 말하면 `<Component {...pageProps}>`의 width가 변하는 게 아니라, `<Component {...pageProps}>`가 사실 **React.Fragment**였기 때문에 **내용물만 덩그러니 남아서** 그렇게 보인 것이었다.

![에러 원인](https://github.com/codestates-seb/seb44_main_016/assets/65957855/e443a371-819e-45bc-8e89-62438c5e3ced)


### 원래 의도했던 상황
```tsx
/* /index.tsx */
export default function HomePage() {
  return <button>Submit</button>;
}
```

`/index.tsx`는 버튼 Element 하나만을 반환한다. 때문에 DOM 구조가 아래와 똑같이 될 것이라고 생각했었다.

```tsx
<FlexPage>
    <Aside />
    <Component>
        <button>Submit</button>
    </Component>
</FlexPage>
```

### 현재 상황

하지만 실제로는 저 감싸는 `<Component>` Element가 없었다.

```tsx
<FlexPage>
    <Aside />
    <button>Submit</button>
</FlexPage>
```

여기서 `<Component {...pageProps}>`는 사실 **React.Fragment**였음을 알 수 있다. 그래서 width가 고정되지 않는 버그, 더 정확히는 알맹이가 하나의 껍데기에 감싸지지 않고 덩그러니 노출되는 버그가 발생했던 것이다.

이를 DOM 구조로 나타내면 다음과 같다.

```tsx
<FlexPage>
    <Aside />
    <>
        <button>Submit</button>
    </>
</FlexPage>
```

## 해결책 및 변경 사항
`<Component {...pageProps}>`**를 제대로 된 컴포넌트에 감싸주기만 하면 문제가 해결된다.**

![image](https://github.com/codestates-seb/seb44_main_016/assets/65957855/c10f2a18-77ba-48fe-a8c9-47238f699476)

따라서 `<SubPage>`를 생성하고 width를 100%로 지정한 뒤 `<Component {...pageProps}>`를 안에 넣었다.

`<Aside>`의 flex-shrink가 0이고, 부모 Element(`<FlexPage>`)의 너비가 고정폭 1140px이므로, `<SubPage>`는 `<Aside>` 영역을 침범하지 않으며 `<FlexPage>` 바깥으로 벗어나지도 않는다. 그리고 `<Aside>`가 없을 경우, `<Aside>`가 있던 영역까지 `<SubPage>`가 채워지게 된다.

![image](https://github.com/codestates-seb/seb44_main_016/assets/65957855/2bbe4ab6-52d6-4787-911f-80b29dc91337)


# 2차 문제점: `<Aside>`의 `<Lower>`가 밑으로 꺼지는 버그 수정

## 수정 결과
![image](https://github.com/codestates-seb/seb44_main_016/assets/65957855/4399f343-a1e6-499f-9ebb-9b678f56d75a)
(은비 님 스크린샷으로 대체)

## 추가 기능
```tsx
margin-left: ${(props) => props.isShowNav && '250px'}; // <Aside> width
```

isShowNav의 유무에 따라 `<SubPage>`의 너비가 바뀌도록 설정.