### PR TITLE
[FE] Homeheader-16: `<HomeHeader>` UI

### DIFF
--- a/client/src/components/Aside.tsx
+++ b/client/src/components/Aside.tsx
@@ -147,6 +147,7 @@ const S = {
     flex-shrink: 0;
     display: flex;
     align-items: flex-start;
+    z-index: 1; // HomeHeader와 겹쳐져 Aside 오른쪽 테두리의 일부가 안 보는 버그 수정
   `,
   AsideInnerContainer: styled.section`
     width: 250px;

--- a/client/src/components/HomeHeader.tsx
+++ b/client/src/components/HomeHeader.tsx
@@ -39,10 +39,10 @@ const S = {
   ...CommonStyles,
   HomeHeaderContainer: styled.header`
     position: fixed;
+    margin-left: 250px;
     width: 890px;
     height: 5rem;
     background-color: white;
-    border-right: 1px solid var(--color-gray08);
     // border: 1px solid;
     display: flex;
     justify-content: center;

--- a/client/src/components/HomeHeader.tsx
+++ b/client/src/components/HomeHeader.tsx
@@ -1,0 +1,71 @@
+import React from 'react'; // useState 사용
+import styled from '@emotion/styled';
+
+import CommonStyles from '../styles/CommonStyles';
+
+export default function HomeHeader() {
+  const [isHomeButtonActive, setIsHomeButtonActive] = React.useState(true);
+  const [isFollowerButtonActive, setIsFollowerButtonActive] =
+    React.useState(false);
+
+  const handleClickHomeButton = () => {
+    setIsHomeButtonActive(true);
+    setIsFollowerButtonActive(false);
+  };
+  const handleClickFollowButton = () => {
+    setIsHomeButtonActive(false);
+    setIsFollowerButtonActive(true);
+  };
+
+  return (
+    <S.HomeHeaderContainer>
+      <S.HomeHeaderButton
+        onClick={handleClickHomeButton}
+        isActive={isHomeButtonActive}
+      >
+        홈
+      </S.HomeHeaderButton>
+      <S.HomeHeaderButton
+        onClick={handleClickFollowButton}
+        isActive={isFollowerButtonActive}
+      >
+        팔로워
+      </S.HomeHeaderButton>
+    </S.HomeHeaderContainer>
+  );
+}
+
+const S = {
+  ...CommonStyles,
+  HomeHeaderContainer: styled.header`
+    position: fixed;
+    width: 890px;
+    height: 5rem;
+    background-color: white;
+    border-right: 1px solid var(--color-gray08);
+    // border: 1px solid;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+  `,
+  HomeHeaderButton: styled.button<{ isActive: boolean }>`
+    width: 6rem;
+    height: 75%;
+    background-color: white;
+    font-size: 18px;
+    font-weight: bold;
+    color: ${(props) => props.isActive && 'var(--color-primary)'};
+    border-bottom: ${(props) =>
+      props.isActive
+        ? '3px solid var(--color-primary)'
+        : '3px solid transparent'};
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    &:hover {
+      filter: brightness(0.9);
+    }
+  `,
+};

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import Aside from '../components/Aside';
+import HomeHeader from '../components/HomeHeader';
 
 const queryClient = new QueryClient();
 
@@ -13,6 +14,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   const router = useRouter();
 
   let isShowNav = true;
+  const isShowHeader = true;
   let bgColor = '#F0F3F8';
   if (router.pathname.startsWith('/user')) {
     isShowNav = false;
@@ -31,6 +33,7 @@ const App = ({ Component, pageProps }: AppProps) => {
             <S.FlexPage>
               {isShowNav && <Aside isLoggedIn={true} />}
               <S.SubPage isShowNav={isShowNav} bgColor={bgColor}>
+                {isShowHeader && <HomeHeader />}
                 <Component {...pageProps} />
               </S.SubPage>
             </S.FlexPage>
@@ -59,16 +62,17 @@ const S = {
   `,
 
   FlexPage: styled.div`
-    display: flex;
     width: 100%;
     height: 100%;
+    display: flex;
   `,
 
   SubPage: styled.div<{ isShowNav: boolean; bgColor?: string }>`
-    display: flex;
     width: 100%;
     height: 100%;
     margin-left: ${(props) => props.isShowNav && '250px'}; // <Aside> width
     background-color: ${(props) => props.bgColor || 'transparent'};
+    display: flex;
+    flex-direction: column;
   `,
 };

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -31,9 +31,9 @@ const App = ({ Component, pageProps }: AppProps) => {
         <S.RootScreen>
           <S.AppContainer>
             <S.FlexPage>
+              {isShowHeader && <HomeHeader />}
               {isShowNav && <Aside isLoggedIn={true} />}
               <S.SubPage isShowNav={isShowNav} bgColor={bgColor}>
-                {isShowHeader && <HomeHeader />}
                 <Component {...pageProps} />
               </S.SubPage>
             </S.FlexPage>
@@ -68,6 +68,7 @@ const S = {
   `,
 
   SubPage: styled.div<{ isShowNav: boolean; bgColor?: string }>`
+    margin-top: 5rem;
     width: 100%;
     height: 100%;
     margin-left: ${(props) => props.isShowNav && '250px'}; // <Aside> width

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -14,8 +14,17 @@ const App = ({ Component, pageProps }: AppProps) => {
   const router = useRouter();
 
   let isShowNav = true;
-  const isShowHeader = true;
+  let isShowHeader = false;
   let bgColor = '#F0F3F8';
+  if (router.pathname.startsWith('/')) {
+    isShowHeader = true;
+  } else if (router.pathname.startsWith('/user')) {
+    isShowNav = false;
+    if (router.pathname.startsWith('/user/signup')) {
+      bgColor = '#FFF';
+    }
+  }
+
   if (router.pathname.startsWith('/user')) {
     isShowNav = false;
     if (router.pathname.startsWith('/user/signup')) {
@@ -31,10 +40,16 @@ const App = ({ Component, pageProps }: AppProps) => {
         <S.RootScreen>
           <S.AppContainer>
             <S.FlexPage>
-              {isShowHeader && <HomeHeader />}
               {isShowNav && <Aside isLoggedIn={true} />}
-              <S.SubPage isShowNav={isShowNav} bgColor={bgColor}>
-                <Component {...pageProps} />
+              <S.SubPage>
+                {isShowHeader && <HomeHeader />}
+                <S.Main
+                  isShowNav={isShowNav}
+                  isShowHeader={isShowHeader}
+                  bgColor={bgColor}
+                >
+                  <Component {...pageProps} />
+                </S.Main>
               </S.SubPage>
             </S.FlexPage>
           </S.AppContainer>
@@ -67,12 +82,20 @@ const S = {
     display: flex;
   `,
 
-  SubPage: styled.div<{ isShowNav: boolean; bgColor?: string }>`
-    margin-top: 5rem;
+  SubPage: styled.div`
     width: 100%;
     height: 100%;
-    margin-left: ${(props) => props.isShowNav && '250px'}; // <Aside> width
+  `,
+
+  Main: styled.main<{
+    isShowNav: boolean;
+    isShowHeader: boolean;
+    bgColor?: string;
+  }>`
+    height: 100%;
     background-color: ${(props) => props.bgColor || 'transparent'};
+    margin-top: ${(props) => props.isShowHeader && '5rem'};
+    margin-left: ${(props) => props.isShowNav && '250px'}; // <Aside> width
     display: flex;
     flex-direction: column;
   `,


### PR DESCRIPTION
# `<HomeHeader>` UI & 기능 구현

> 🚨 주의! `trunk`로의 다이렉트 Merge입니다.

## 구현한 기능
* 버튼 UI: 홈, 팔로잉
* design: 활성화/비활성화 버튼별 디자인 구분 (글자 색, font-weight, border-bottom)
* feat: 비활성화 버튼 클릭 시 활성화 디자인으로 전환
  * 반대로 활성화 버튼은 비활성화로
* isShowHeader 변수를 이용, `<HomeHeader>` `<SubPage>` `<Main>` 영역 간 레이아웃 개선

## 추후 개선점
* **반응형 적용**
* 로그아웃 상태에서 [팔로우] 버튼 클릭 → 로그인 페이지로 라우팅
* [홈] 버튼 클릭 → 모든 게시글 표시 (최신순)
* [팔로잉] 버튼 클릭 → 팔로우한 유저의 게시글만 표시 (최신순)
* 명예의 전당 쿼리 적용 시
  * Header에 2버튼 사라지고 `"명예의 전당"` 문자열 표시
* 검색 쿼리 적용 시 : `"‘{검색어}’에 대한 검색 결과"` 문자열 표시
  * Header에 2버튼 사라지고 `"‘{검색어}’에 대한 검색 결과"` 문자열 표시

<br/>