### PR TITLE
[BE] Feat: 가계부 게시글 관련 유효성 검증 추가

### DIFF
--- a/server/build/generated/sources/annotationProcessor/java/main/com/zerohip/server/financialRecord/mapper/FinancialRecordMapperImpl.java
+++ b/server/build/generated/sources/annotationProcessor/java/main/com/zerohip/server/financialRecord/mapper/FinancialRecordMapperImpl.java
@@ -1,0 +1,74 @@
+package com.zerohip.server.financialRecord.mapper;
+
+import com.zerohip.server.financialRecord.dto.FinancialRecordDto;
+import com.zerohip.server.financialRecord.entity.FinancialRecord;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+import org.springframework.stereotype.Component;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2023-07-06T14:18:57+0900",
+    comments = "version: 1.5.3.Final, compiler: IncrementalProcessingEnvironment from gradle-language-java-8.1.1.jar, environment: Java 17.0.7 (Amazon.com Inc.)"
+)
+@Component
+public class FinancialRecordMapperImpl implements FinancialRecordMapper {
+
+    @Override
+    public FinancialRecord financialRecordPostToFinancialRecord(FinancialRecordDto.Post requestBody) {
+        if ( requestBody == null ) {
+            return null;
+        }
+
+        FinancialRecord financialRecord = new FinancialRecord();
+
+        financialRecord.setFinancialRecordName( requestBody.getFinancialRecordName() );
+
+        return financialRecord;
+    }
+
+    @Override
+    public FinancialRecord financialRecordPatchToFinancialRecord(FinancialRecordDto.Patch requestBody) {
+        if ( requestBody == null ) {
+            return null;
+        }
+
+        FinancialRecord financialRecord = new FinancialRecord();
+
+        financialRecord.setFinancialRecordName( requestBody.getFinancialRecordName() );
+
+        return financialRecord;
+    }
+
+    @Override
+    public FinancialRecordDto.Response financialRecordToFinancialRecordResponse(FinancialRecord financialRecord) {
+        if ( financialRecord == null ) {
+            return null;
+        }
+
+        Long financialRecordId = null;
+        String financialRecordName = null;
+
+        financialRecordId = financialRecord.getFinancialRecordId();
+        financialRecordName = financialRecord.getFinancialRecordName();
+
+        FinancialRecordDto.Response response = new FinancialRecordDto.Response( financialRecordId, financialRecordName );
+
+        return response;
+    }
+
+    @Override
+    public List<FinancialRecordDto.Response> financialRecordsToFinancialRecordResponses(List<FinancialRecord> financialRecords) {
+        if ( financialRecords == null ) {
+            return null;
+        }
+
+        List<FinancialRecordDto.Response> list = new ArrayList<FinancialRecordDto.Response>( financialRecords.size() );
+        for ( FinancialRecord financialRecord : financialRecords ) {
+            list.add( financialRecordToFinancialRecordResponse( financialRecord ) );
+        }
+
+        return list;
+    }
+}

--- a/server/src/main/java/com/zerohip/server/common/scope/Scope.java
+++ b/server/src/main/java/com/zerohip/server/common/scope/Scope.java
@@ -1,0 +1,2 @@
+package com.zerohip.server.common.scope;public enum Scope {
+}

--- a/server/src/main/java/com/zerohip/server/common/scope/Scope.java
+++ b/server/src/main/java/com/zerohip/server/common/scope/Scope.java
@@ -1,2 +1,17 @@
-package com.zerohip.server.common.scope;public enum Scope {
+package com.zerohip.server.common.scope;
+
+public enum Scope {
+  FAREC_ARTICLE("가계부"),
+  FAREC_TIMELINE("가계부 게시글"),
+  FEED("피드");
+
+  private String scope;
+
+  Scope(String description) {
+    this.scope = description;
+  }
+
+  public String getScope() {
+    return scope;
+  }
 }

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
@@ -28,6 +28,8 @@ public class FinancialRecordArticleDto {
     @NotBlank
     private String category;
     @NotNull
+    private int price;
+    @NotNull
     private Scope scope;
 
     // 가계부 매핑 데이터
@@ -51,6 +53,8 @@ public class FinancialRecordArticleDto {
     @Size(min = 1, max = 10)
     private String category;
     @NotNull
+    private int price;
+    @NotNull
     private Scope scope;
 
     // 가계부 매핑 데이터
@@ -73,6 +77,8 @@ public class FinancialRecordArticleDto {
     private Date faDate;
     @NotBlank
     private String category;
+    @NotNull
+    private int price;
     @NotNull
     private Scope scope;
 

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
@@ -1,0 +1,85 @@
+package com.zerohip.server.financialRecordArticle.dto;
+
+import com.zerohip.server.common.audit.Auditable;
+import com.zerohip.server.common.scope.Scope;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.persistence.Column;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class FinancialRecordArticleDto {
+
+  @Getter
+  @AllArgsConstructor
+  public static class Post {
+    @Size(max = 30)
+    private String title;
+    @Size(max = 10000)
+    private String content;
+    @NotBlank
+    private String faDate;
+    @NotBlank
+    private String category;
+    @NotNull
+    private Scope scope;
+
+    // 가계부 매핑 데이터
+    // 유저 매핑 데이터
+    // 이미지 매핑 데이터
+    // 댓글 매핑 데이터
+    // 좋아요 매핑 데이터
+    // 해시태그 매핑 데이터
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class Patch {
+    @Size(max = 30)
+    private String title;
+    @Size(max = 10000)
+    private String content;
+    @NotBlank
+    private String faDate;
+    @NotBlank
+    @Size(min = 1, max = 10)
+    private String category;
+    @NotNull
+    private Scope scope;
+
+    // 가계부 매핑 데이터
+    // 유저 매핑 데이터
+    // 이미지 매핑 데이터
+    // 댓글 매핑 데이터
+    // 좋아요 매핑 데이터
+    // 해시태그 매핑 데이터
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class Response extends Auditable {
+    private Long financialRecordArticleId;
+    @Size(max = 30)
+    private String title;
+    @Size(max = 10000)
+    private String content;
+    @NotBlank
+    private String faDate;
+    @NotBlank
+    private String category;
+    @NotNull
+    private Scope scope;
+
+    // 가계부 매핑 데이터
+    // 유저 매핑 데이터
+    // 이미지 매핑 데이터
+    // 댓글 매핑 데이터
+    // 좋아요 매핑 데이터
+    // 해시태그 매핑 데이터
+  }
+}

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
@@ -29,7 +29,7 @@ public class FinancialRecordArticleDto {
     @NotBlank
     private String category;
     @NotNull
-    private int price;
+    private Integer price;
     @NotNull
     private Scope scope;
 
@@ -54,7 +54,7 @@ public class FinancialRecordArticleDto {
     @Size(min = 1, max = 10)
     private String category;
     @NotNull
-    private int price;
+    private Integer price;
     @NotNull
     private Scope scope;
 
@@ -79,7 +79,7 @@ public class FinancialRecordArticleDto {
     @NotBlank
     private String category;
     @NotNull
-    private int price;
+    private Integer price;
     @NotNull
     private Scope scope;
 

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
@@ -12,6 +12,7 @@ import javax.persistence.Id;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.Date;
 
 public class FinancialRecordArticleDto {
 
@@ -22,8 +23,8 @@ public class FinancialRecordArticleDto {
     private String title;
     @Size(max = 10000)
     private String content;
-    @NotBlank
-    private String faDate;
+    @NotNull
+    private Date faDate;
     @NotBlank
     private String category;
     @NotNull
@@ -44,8 +45,8 @@ public class FinancialRecordArticleDto {
     private String title;
     @Size(max = 10000)
     private String content;
-    @NotBlank
-    private String faDate;
+    @NotNull
+    private Date faDate;
     @NotBlank
     @Size(min = 1, max = 10)
     private String category;
@@ -68,8 +69,8 @@ public class FinancialRecordArticleDto {
     private String title;
     @Size(max = 10000)
     private String content;
-    @NotBlank
-    private String faDate;
+    @NotNull
+    private Date faDate;
     @NotBlank
     private String category;
     @NotNull

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
@@ -12,6 +12,7 @@ import javax.persistence.Id;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
 import java.util.Date;
 
 public class FinancialRecordArticleDto {
@@ -67,7 +68,7 @@ public class FinancialRecordArticleDto {
 
   @Getter
   @AllArgsConstructor
-  public static class Response extends Auditable {
+  public static class Response {
     private Long financialRecordArticleId;
     @Size(max = 30)
     private String title;
@@ -81,6 +82,9 @@ public class FinancialRecordArticleDto {
     private int price;
     @NotNull
     private Scope scope;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
 
     // 가계부 매핑 데이터
     // 유저 매핑 데이터

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
@@ -1,7 +1,53 @@
 package com.zerohip.server.financialRecordArticle.entity;
 
-import javax.persistence.Entity;
+import com.zerohip.server.common.scope.Scope;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@NoArgsConstructor
+@Setter
+@Getter
 @Entity
 public class FinancialRecordArticle {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long financialRecordArticleId;
+
+  @Size(max = 30)
+  @Column(nullable = true, unique = false, updatable = true, length = 30)
+  private String title;
+  @Size(max = 10000)
+  @Column(nullable = true, unique = false, updatable = true, length = 10000)
+  private String content;
+  @NotBlank
+  @Column(nullable = false, unique = false, updatable = true)
+  private String faDate;
+  @NotBlank
+  @Size(min = 1, max = 10)
+  @Column(nullable = false, unique = false, updatable = true, length = 10)
+  private String category;
+
+  /**
+   * 글의 공개 범위
+   * - 가계부 게시글(FAREC_ARTICLE)
+   * - 가계부 게시글(FAREC_TIMELINE)
+   * - 피드(FEED)
+   */
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  private Scope scope;
+
+  // 가계부 매핑
+  // 유저 매핑
+  // 이미지 매핑
+  // 댓글 매핑
+  // 좋아요 매핑
+  // 해시태그 매핑
 }

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
@@ -1,6 +1,7 @@
 package com.zerohip.server.financialRecordArticle.entity;
 
 import com.zerohip.server.common.scope.Scope;
+import com.zerohip.server.financialRecord.entity.FinancialRecord;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,6 +23,17 @@ import java.util.Date;
 @Entity
 public class FinancialRecordArticle {
 
+  public FinancialRecordArticle(Long financialRecordArticleId, String title, String content, Date faDate, String category, int price, Scope scope, FinancialRecord financialRecord) {
+    this.financialRecordArticleId = financialRecordArticleId;
+    this.title = title;
+    this.content = content;
+    this.faDate = faDate;
+    this.category = category;
+    this.price = price;
+    this.scope = scope;
+    this.financialRecord = financialRecord;
+  }
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long financialRecordArticleId;
@@ -39,6 +51,9 @@ public class FinancialRecordArticle {
   @Size(min = 1, max = 10)
   @Column(nullable = false, unique = false, updatable = true, length = 10)
   private String category;
+  @NotNull
+  @Column(nullable = false, unique = false, updatable = true)
+  private int price;
 
   /**
    * 글의 공개 범위
@@ -51,6 +66,9 @@ public class FinancialRecordArticle {
   private Scope scope;
 
   // 가계부 매핑
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "financialRecordId")
+  private FinancialRecord financialRecord;
   // 유저 매핑
   // 이미지 매핑
   // 댓글 매핑

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
@@ -9,7 +9,13 @@ import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.Date;
 
+/**
+ * faDate를 어떻게 저장할 것인가..!
+ * Date!? String!?
+ * - String으로 저장하면, 조회할 때, String을 Date로 변환해야 한다.
+ */
 @NoArgsConstructor
 @Setter
 @Getter
@@ -26,9 +32,9 @@ public class FinancialRecordArticle {
   @Size(max = 10000)
   @Column(nullable = true, unique = false, updatable = true, length = 10000)
   private String content;
-  @NotBlank
+  @NotNull
   @Column(nullable = false, unique = false, updatable = true)
-  private String faDate;
+  private Date faDate;
   @NotBlank
   @Size(min = 1, max = 10)
   @Column(nullable = false, unique = false, updatable = true, length = 10)

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
@@ -34,6 +34,17 @@ public class FinancialRecordArticle {
     this.financialRecord = financialRecord;
   }
 
+  // No financialRecord
+  public FinancialRecordArticle(Long financialRecordArticleId, String title, String content, Date faDate, String category, int price, Scope scope) {
+    this.financialRecordArticleId = financialRecordArticleId;
+    this.title = title;
+    this.content = content;
+    this.faDate = faDate;
+    this.category = category;
+    this.price = price;
+    this.scope = scope;
+  }
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long financialRecordArticleId;

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
@@ -64,7 +64,7 @@ public class FinancialRecordArticle {
   private String category;
   @NotNull
   @Column(nullable = false, unique = false, updatable = true)
-  private int price;
+  private Integer price;
 
   /**
    * 글의 공개 범위

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
@@ -23,8 +23,7 @@ import java.util.Date;
 @Entity
 public class FinancialRecordArticle {
 
-  public FinancialRecordArticle(Long financialRecordArticleId, String title, String content, Date faDate, String category, int price, Scope scope, FinancialRecord financialRecord) {
-    this.financialRecordArticleId = financialRecordArticleId;
+  public FinancialRecordArticle(String title, String content, Date faDate, String category, int price, Scope scope, FinancialRecord financialRecord) {
     this.title = title;
     this.content = content;
     this.faDate = faDate;
@@ -35,8 +34,7 @@ public class FinancialRecordArticle {
   }
 
   // No financialRecord
-  public FinancialRecordArticle(Long financialRecordArticleId, String title, String content, Date faDate, String category, int price, Scope scope) {
-    this.financialRecordArticleId = financialRecordArticleId;
+  public FinancialRecordArticle(String title, String content, Date faDate, String category, int price, Scope scope) {
     this.title = title;
     this.content = content;
     this.faDate = faDate;

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleService.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleService.java
@@ -1,5 +1,6 @@
 package com.zerohip.server.financialRecordArticle.service;
 
+import com.zerohip.server.financialRecordArticle.dto.FinancialRecordArticleDto;
 import com.zerohip.server.financialRecordArticle.entity.FinancialRecordArticle;
 
 import java.util.List;
@@ -7,14 +8,16 @@ import java.util.List;
 public interface FinancialRecordArticleService {
 
   // 가계부 게시글 생성
-  FinancialRecordArticle createFaRecArticle(FinancialRecordArticle faRecArticle);
+  FinancialRecordArticle createFaRecArticle(Long financialRecordId, FinancialRecordArticle faRecArticle);
 
   // 가계부 게시글 조회(단건)
   FinancialRecordArticle findFaRecArticle(Long faRecArticleId);
   // 가계부 게시글 조회(전체)
-  List<FinancialRecordArticle> findFaRecArticles();
+  List<FinancialRecordArticle> findFaRecArticles(Long financialRecordId);
   // 가계부 게시글 수정
-  FinancialRecordArticle updateFaRecArticle(Long faRecArticleId, FinancialRecordArticle.Patch patchParam);
+  FinancialRecordArticle updateFaRecArticle(Long faRecArticleId, FinancialRecordArticleDto.Patch patchParam);
   // 가계부 게시글 삭제
   void deleteFaRecArticle(Long faRecArticleId);
+  // 가계부 게시글 조회 확인
+  FinancialRecordArticle findVerifiedFaRecArticle(Long faRecArticleId);
 }

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleServiceImpl.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleServiceImpl.java
@@ -1,2 +1,99 @@
-package com.zerohip.server.financialRecordArticle.service;public class FinancialRecordArticleServiceImpl {
+package com.zerohip.server.financialRecordArticle.service;
+
+import com.zerohip.server.financialRecord.entity.FinancialRecord;
+import com.zerohip.server.financialRecord.repository.FinancialRecordRepository;
+import com.zerohip.server.financialRecord.service.FinancialRecordService;
+import com.zerohip.server.financialRecordArticle.dto.FinancialRecordArticleDto;
+import com.zerohip.server.financialRecordArticle.entity.FinancialRecordArticle;
+import com.zerohip.server.financialRecordArticle.repository.FinancialRecordArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FinancialRecordArticleServiceImpl implements FinancialRecordArticleService {
+
+  // 결합도 관련해서 고민이 필요해 보임
+  private final FinancialRecordService financialRecordService;
+  private final FinancialRecordArticleRepository repository;
+
+  @Override
+  public FinancialRecordArticle createFaRecArticle(Long financialRecordId, FinancialRecordArticle faRecArticle) {
+    // 해당 가계부가 존재하는지 확인 -> 없으면 예외를 발생시키고 있으면 해당 가계부를 반환
+    FinancialRecord faRec = financialRecordService.findFaRec(financialRecordId);
+
+    // FinancialRecordArticle과 FinancialRecord의 관계를 설정
+    faRecArticle.setFinancialRecord(faRec);
+
+    // FinancialRecordArticle의 유효성 검사
+    validateFaRecArticle(faRecArticle);
+
+    return repository.save(faRecArticle);
+  }
+
+  // 가계부 조회(단건)
+  @Override
+  public FinancialRecordArticle findFaRecArticle(Long faRecArticleId) {
+    return findVerifiedFaRecArticle(faRecArticleId);
+  }
+
+  // 가계부 전체 조회(동적쿼리 사용 예정)
+  @Override
+  public List<FinancialRecordArticle> findFaRecArticles(Long financialRecordId) {
+    return repository.findAll();
+  }
+
+  // 가계부 수정
+  @Override
+  public FinancialRecordArticle updateFaRecArticle(Long faRecArticleId, FinancialRecordArticleDto.Patch patchParam) {
+    FinancialRecordArticle findFaRecArticle = findVerifiedFaRecArticle(faRecArticleId);
+    findFaRecArticle.setTitle(patchParam.getTitle());
+    findFaRecArticle.setContent(patchParam.getContent());
+    findFaRecArticle.setFaDate(patchParam.getFaDate());
+    findFaRecArticle.setCategory(patchParam.getCategory());
+    findFaRecArticle.setPrice(patchParam.getPrice());
+    findFaRecArticle.setScope(patchParam.getScope());
+
+    FinancialRecordArticle updateFaRecArticle = repository.save(findFaRecArticle);
+    return updateFaRecArticle;
+  }
+
+  @Override
+  public void deleteFaRecArticle(Long faRecArticleId) {
+    FinancialRecordArticle findFaRecArticle = findVerifiedFaRecArticle(faRecArticleId);
+    repository.delete(findFaRecArticle);
+  }
+
+  @Override
+  public FinancialRecordArticle findVerifiedFaRecArticle(Long faRecArticleId) {
+    Optional<FinancialRecordArticle> optionalFaRecArticle = repository.findById(faRecArticleId);
+    FinancialRecordArticle findFaRecArticle = optionalFaRecArticle.orElseThrow(() -> new RuntimeException("해당 게시글이 존재하지 않습니다."));
+    return findFaRecArticle;
+  }
+
+  // FinancialRecordArticle의 유효성 검사
+  private void validateFaRecArticle(FinancialRecordArticle faRecArticle) {
+    if (faRecArticle == null) {
+      throw new IllegalArgumentException("게시글은 null이 될 수 없습니다.");
+    }
+    if (faRecArticle.getTitle() == null ||
+            faRecArticle.getTitle().trim().isEmpty() ||
+            faRecArticle.getTitle().length() > 30) {
+      throw new IllegalArgumentException("게시글의 제목은 null이 될 수 없고, 30자를 넘을 수 없습니다.");
+    }
+    if (faRecArticle.getContent() == null ||
+            faRecArticle.getContent().trim().isEmpty() ||
+            faRecArticle.getContent().length() > 10000) {
+      throw new IllegalArgumentException("게시글의 내용은 null이 될 수 없고, 10000자를 넘을 수 없습니다.");
+    }
+    // 다른 필드들에 대한 유효성 검사를 추가 가능.
+  }
+
+
+
 }

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleServiceImpl.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleServiceImpl.java
@@ -1,0 +1,2 @@
+package com.zerohip.server.financialRecordArticle.service;public class FinancialRecordArticleServiceImpl {
+}

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleServiceImpl.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleServiceImpl.java
@@ -1,5 +1,6 @@
 package com.zerohip.server.financialRecordArticle.service;
 
+import com.zerohip.server.common.scope.Scope;
 import com.zerohip.server.financialRecord.entity.FinancialRecord;
 import com.zerohip.server.financialRecord.repository.FinancialRecordRepository;
 import com.zerohip.server.financialRecord.service.FinancialRecordService;
@@ -81,19 +82,22 @@ public class FinancialRecordArticleServiceImpl implements FinancialRecordArticle
     if (faRecArticle == null) {
       throw new IllegalArgumentException("게시글은 null이 될 수 없습니다.");
     }
+    if (faRecArticle.getScope().equals(Scope.FEED)) {
+      throw new IllegalArgumentException("게시글의 공개 범위는 FEED가 될 수 없습니다.");
+    }
     if (faRecArticle.getTitle() == null ||
             faRecArticle.getTitle().trim().isEmpty() ||
             faRecArticle.getTitle().length() > 30) {
       throw new IllegalArgumentException("게시글의 제목은 null이 될 수 없고, 30자를 넘을 수 없습니다.");
     }
-    if (faRecArticle.getContent() == null ||
-            faRecArticle.getContent().trim().isEmpty() ||
-            faRecArticle.getContent().length() > 10000) {
+    if (faRecArticle.getContent().length() > 10000) {
       throw new IllegalArgumentException("게시글의 내용은 null이 될 수 없고, 10000자를 넘을 수 없습니다.");
     }
-    // 다른 필드들에 대한 유효성 검사를 추가 가능.
+    if (faRecArticle.getFaDate() == null ||
+      faRecArticle.getCategory() == null ||
+      faRecArticle.getPrice() == null) {
+      throw new IllegalArgumentException("해당 필드는 null또는 Blank이(가) 될 수 없습니다.");
+    }
+    // if문이 너무 많네요,, 수정의 필요성이 있어보입니다.
   }
-
-
-
 }

--- a/server/src/test/java/com/zerohip/server/financialRecordArticle/repository/FinancialRecordArticleRepositoryTest.java
+++ b/server/src/test/java/com/zerohip/server/financialRecordArticle/repository/FinancialRecordArticleRepositoryTest.java
@@ -1,4 +1,52 @@
+package com.zerohip.server.financialRecordArticle.repository;
+
+import com.zerohip.server.financialRecordArticle.entity.FinancialRecordArticle;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
 import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@Transactional
+@SpringBootTest
 class FinancialRecordArticleRepositoryTest {
-  
+
+  @Autowired
+  FinancialRecordArticleRepository financialRecordArticleRepository;
+
+  @Test
+  @DisplayName("가계부 기록 생성")
+  void save() {
+    new FinancialRecordArticle();
+  }
+
+  @Test
+  @DisplayName("가계부 기록 조회(단건)")
+  void findById() {
+    new FinancialRecordArticle();
+  }
+
+  @Test
+  @DisplayName("가계부 기록 조회(전체)")
+  void findAll() {
+    new FinancialRecordArticle();
+  }
+
+  @Test
+  @DisplayName("가계부 기록 수정")
+  void update() {
+    new FinancialRecordArticle();
+  }
+
+  @Test
+  @DisplayName("가계부 기록 삭제")
+  void delete() {
+    new FinancialRecordArticle();
+  }
+
 }

--- a/server/src/test/java/com/zerohip/server/financialRecordArticle/repository/FinancialRecordArticleRepositoryTest.java
+++ b/server/src/test/java/com/zerohip/server/financialRecordArticle/repository/FinancialRecordArticleRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.zerohip.server.financialRecordArticle.repository;
 
+import com.zerohip.server.common.scope.Scope;
 import com.zerohip.server.financialRecordArticle.entity.FinancialRecordArticle;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,6 +11,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
@@ -19,34 +26,115 @@ class FinancialRecordArticleRepositoryTest {
   @Autowired
   FinancialRecordArticleRepository financialRecordArticleRepository;
 
+  Date now;
+  FinancialRecordArticle financialRecordArticle;
+  @BeforeEach
+  void setUp() {
+    now = new Date();
+    financialRecordArticle = new FinancialRecordArticle("test title", "test content", now, "테스트", 1000, Scope.FAREC_ARTICLE);
+    log.info("A new FinancialRecordArticle has been set up with ID: " + financialRecordArticle.getFinancialRecordArticleId());
+  }
+
   @Test
   @DisplayName("가계부 기록 생성")
   void save() {
-    new FinancialRecordArticle();
+
+    FinancialRecordArticle saveFaRecArticle = financialRecordArticleRepository.save(financialRecordArticle);
+    log.info("saveFaRecArticle.getTitle() = {}", saveFaRecArticle.getTitle());
+    log.info("saveFaRecArticle.getContent() = {}", saveFaRecArticle.getContent());
+    log.info("saveFaRecArticle.getFaDate() = {}", saveFaRecArticle.getFaDate());
+    log.info("saveFaRecArticle.getCategory() = {}", saveFaRecArticle.getCategory());
+    log.info("saveFaRecArticle.getPrice() = {}", saveFaRecArticle.getPrice());
+    log.info("saveFaRecArticle.getScope() = {}", saveFaRecArticle.getScope());
+
+    // Verify
+    assertEquals(financialRecordArticle.getTitle(), saveFaRecArticle.getTitle());
+    assertEquals(financialRecordArticle.getContent(), saveFaRecArticle.getContent());
+    assertEquals(financialRecordArticle.getFaDate(), saveFaRecArticle.getFaDate());
+    assertEquals(financialRecordArticle.getCategory(), saveFaRecArticle.getCategory());
+    assertEquals(financialRecordArticle.getPrice(), saveFaRecArticle.getPrice());
+    assertEquals(financialRecordArticle.getScope(), saveFaRecArticle.getScope());
+    assertNotNull(saveFaRecArticle);
+    assertNotNull(saveFaRecArticle.getFinancialRecordArticleId());
+
   }
 
   @Test
   @DisplayName("가계부 기록 조회(단건)")
   void findById() {
-    new FinancialRecordArticle();
+    FinancialRecordArticle saveFaRecArticle = financialRecordArticleRepository.save(financialRecordArticle);
+    Optional<FinancialRecordArticle> optionalFaRecArticle = financialRecordArticleRepository.findById(saveFaRecArticle.getFinancialRecordArticleId());
+    FinancialRecordArticle findFaRecArticle = optionalFaRecArticle.orElseThrow(() -> new RuntimeException("가계부 기록이 없습니다."));
+
+    // Verify
+    assertEquals(financialRecordArticle.getTitle(), findFaRecArticle.getTitle());
+    assertEquals(financialRecordArticle.getContent(), findFaRecArticle.getContent());
+    assertEquals(financialRecordArticle.getFaDate(), findFaRecArticle.getFaDate());
+    assertEquals(financialRecordArticle.getCategory(), findFaRecArticle.getCategory());
+    assertEquals(financialRecordArticle.getPrice(), findFaRecArticle.getPrice());
+    assertEquals(financialRecordArticle.getScope(), findFaRecArticle.getScope());
+    assertNotNull(findFaRecArticle);
+    assertNotNull(findFaRecArticle.getFinancialRecordArticleId());
   }
 
   @Test
   @DisplayName("가계부 기록 조회(전체)")
   void findAll() {
-    new FinancialRecordArticle();
+    FinancialRecordArticle saveFaRecArticle1 = financialRecordArticleRepository.save(financialRecordArticle);
+    log.info("saveFaRecArticle.getTitle() = {}", saveFaRecArticle1.getTitle());
+
+    FinancialRecordArticle financialRecordArticle2 = new FinancialRecordArticle("test title2", "test content2", now, "테스트2", 2000, Scope.FAREC_ARTICLE);
+    FinancialRecordArticle saveFaRecArticle2 = financialRecordArticleRepository.save(financialRecordArticle2);
+
+    log.info("saveFaRecArticle1.getId() = {}", saveFaRecArticle1.getFinancialRecordArticleId());
+    log.info("saveFaRecArticle2.getId() = {}", saveFaRecArticle2.getFinancialRecordArticleId());
+
+
+    List<FinancialRecordArticle> findFaRecArticles = financialRecordArticleRepository.findAll();
+
+    // Verify
+    assertThat(findFaRecArticles.size()).isEqualTo(2);
+    assertThat(findFaRecArticles).contains(saveFaRecArticle1, saveFaRecArticle2);
   }
 
   @Test
   @DisplayName("가계부 기록 수정")
   void update() {
-    new FinancialRecordArticle();
+    FinancialRecordArticle saveFaRecArticle = financialRecordArticleRepository.save(financialRecordArticle);
+    Optional<FinancialRecordArticle> optionalFaRecArticle = financialRecordArticleRepository.findById(saveFaRecArticle.getFinancialRecordArticleId());
+    FinancialRecordArticle findFaRecArticle = optionalFaRecArticle.orElseThrow(() -> new RuntimeException("가계부 기록이 없습니다."));
+    findFaRecArticle.setTitle("update title");
+    findFaRecArticle.setContent("update content");
+
+    FinancialRecordArticle updateFaRecArticle = financialRecordArticleRepository.save(findFaRecArticle);
+    log.info("updateFaRecArticle.getTitle() = {}", updateFaRecArticle.getTitle());
+    log.info("updateFaRecArticle.getContent() = {}", updateFaRecArticle.getContent());
+    log.info("updateFaRecArticle.getFaDate() = {}", updateFaRecArticle.getFaDate());
+    log.info("updateFaRecArticle.getCategory() = {}", updateFaRecArticle.getCategory());
+    log.info("updateFaRecArticle.getPrice() = {}", updateFaRecArticle.getPrice());
+    log.info("updateFaRecArticle.getScope() = {}", updateFaRecArticle.getScope());
+
+
+    // Verify
+    assertEquals(findFaRecArticle.getTitle(), updateFaRecArticle.getTitle());
+    assertEquals(findFaRecArticle.getContent(), updateFaRecArticle.getContent());
+    assertEquals(findFaRecArticle.getFaDate(), updateFaRecArticle.getFaDate());
+    assertEquals(findFaRecArticle.getCategory(), updateFaRecArticle.getCategory());
+    assertEquals(findFaRecArticle.getPrice(), updateFaRecArticle.getPrice());
+    assertEquals(findFaRecArticle.getScope(), updateFaRecArticle.getScope());
   }
 
   @Test
   @DisplayName("가계부 기록 삭제")
   void delete() {
-    new FinancialRecordArticle();
+    FinancialRecordArticle saveFaRecArticle = financialRecordArticleRepository.save(financialRecordArticle);
+    financialRecordArticleRepository.delete(saveFaRecArticle);
+
+    Optional<FinancialRecordArticle> optionalFaRecArticle = financialRecordArticleRepository.findById(saveFaRecArticle.getFinancialRecordArticleId());
+    FinancialRecordArticle findFaRecArticle = optionalFaRecArticle.orElse(null);
+
+    // Verify
+    assertNull(findFaRecArticle);
   }
 
 }

--- a/server/src/test/java/com/zerohip/server/financialRecordArticle/repository/FinancialRecordArticleRepositoryTest.java
+++ b/server/src/test/java/com/zerohip/server/financialRecordArticle/repository/FinancialRecordArticleRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class FinancialRecordArticleRepositoryTest {
+  
+}


### PR DESCRIPTION
## 구현한 기능
1. Null값 유효성 검사를 위해 price int -> Integer
2. 가계부 수입/지출 날짜 작성 String -> Date
3. 공개범위에 대한 공통 ENUM은 dto, entity, service와 함께 새로운 공통브랜치에 공유할 수 있도록 하겠습니다
4. Dto.Response부분에 Auditable 확장 해제 및 필드변수 추가
5. 비즈니스 로직레벨에서 유효성 검사 메서드 추가
6. 가계부 매핑전 테스트를 위한 가계부 정보 제외한 생성자 추가
<br/>

## 비고

- repositoryTest코드는 완료되었으나 어제 각각의 테스트는 통과했으나
- 전체 테스트에서 전체조회 부분에서 문제가 발생했습니다. 해당 부분 수정 후 따로 PR요청 드릴 수 있도록 하겠습니다.
