### PR TITLE
[FE] designsemantic-109: `<HomeHeader>`, `<Aside>` 디자인/시맨틱 개선

### DIFF
--- a/client/src/components/Aside.tsx
+++ b/client/src/components/Aside.tsx
@@ -38,7 +38,8 @@ export default function Aside(props: Props) {
   };
 
   return (
-    <S.AsideContainer>
+    <S.AsideContainer isTabClosed={isTabClosed}>
+      <S.LeftOfAsideCover />
       <S.AsideInnerContainer>
         <S.Upper>
           <AsideLogo isTabClosed={isTabClosed} />
@@ -123,8 +124,8 @@ export default function Aside(props: Props) {
 
 const S = {
   ...CommonStyles,
-  AsideContainer: styled.aside`
-    width: var(--aside-w);
+  AsideContainer: styled.aside<{ isTabClosed?: boolean | undefined }>`
+    width: ${(props) => (props.isTabClosed ? 'var(--aside-w)' : '5rem')};
     position: fixed;
     height: 100%;
     flex-shrink: 0;
@@ -132,20 +133,34 @@ const S = {
     align-items: flex-start;
     z-index: 1; // HomeHeader와 겹쳐져 Aside 오른쪽 테두리의 일부가 안 보는 버그 수정
   `,
-  AsideInnerContainer: styled.section`
+  LeftOfAsideCover: styled.div`
+    position: absolute;
+    width: var(--aside-tab-w);
+    left: calc(var(--aside-tab-w) * -1);
+    background-color: white;
+    height: 100%;
+  `,
+  AsideInnerContainer: styled.div`
     width: 100%;
     border-right: 0.05rem solid var(--color-gray08);
     background-color: white;
     height: 100%;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     align-items: flex-end;
+
+    animation: fadein 0.5s;
+    @keyframes fadein {
+      from {
+        left: -10rem;
+      }
+    }
   `,
-  Upper: styled.section`
+  Upper: styled.div`
     width: 100%;
-    height: 100%;
   `,
-  Lower: styled.section`
+  Lower: styled.div`
     width: 100%;
     display: flex;
     flex-direction: column;
@@ -159,12 +174,11 @@ const S = {
     padding: 1rem 0rem;
   `,
 
-  TabContainer: styled.section`
+  TabContainer: styled.div`
     left: 5rem;
-    border-left: 1px solid var(--color-gray08);
     border-right: 1px solid var(--color-gray08);
     position: absolute;
-    width: 22rem;
+    width: var(--aside-tab-w);
     height: 100%;
     background-color: white;
     font-weight: bold;
@@ -173,15 +187,24 @@ const S = {
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: -1;
+
+    animation: fadein 0.5s;
+    @keyframes fadein {
+      from {
+        left: -10rem;
+      }
+    }
   `,
   CloseTabButton: styled.button`
     position: absolute;
     top: 0rem;
     right: 1rem;
     color: var(--color-gray02);
+    font-weight: 100;
   `,
   /*
-  Backdrop: styled.section`
+  Backdrop: styled.div`
     position: absolute;
     left: 5rem;
     background-color: pink;

--- a/client/src/components/Aside.tsx
+++ b/client/src/components/Aside.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import CommonStyles from '../styles/CommonStyles';
 import AsideButton from '../components/aside/AsideButton';
+import AsideLogo from '../components/aside/AsideLogo';
 import SvgBox from '../components/aside/SvgBox';
 
 import svgs from '../constants/svg';
@@ -40,15 +41,11 @@ export default function Aside(props: Props) {
     <S.AsideContainer>
       <S.AsideInnerContainer>
         <S.Upper>
-          <S.Logo>
-            <SvgBox>{svgs.logoSymbol}</SvgBox>
-            {isTabClosed && svgs.logotext}
-          </S.Logo>
+          <AsideLogo isTabClosed={isTabClosed} />
           <ol>
             <AsideButton leftIcon={svgs.home}>
               {isTabClosed && '홈'}
             </AsideButton>
-
             {props.isLoggedIn && (
               <>
                 <AsideButton
@@ -169,14 +166,6 @@ const S = {
     padding: 1.5rem 0rem;
   `,
 
-  Logo: styled.button`
-    width: 100%;
-    height: 3.25rem;
-    padding-left: 1rem;
-    margin: 2rem 0rem;
-    display: flex;
-    align-items: center;
-  `,
   BookmarkedFaRecButton: styled.button`
     width: 100%;
     padding: 1rem 0rem;

--- a/client/src/components/Aside.tsx
+++ b/client/src/components/Aside.tsx
@@ -139,18 +139,18 @@ export default function Aside(props: Props) {
 const S = {
   ...CommonStyles,
   AsideContainer: styled.aside`
+    width: var(--aside-w);
     position: fixed;
     height: 100%;
-    background-color: white;
-    border-right: 1px solid var(--color-gray08);
-    // border: 1px solid;
     flex-shrink: 0;
     display: flex;
     align-items: flex-start;
     z-index: 1; // HomeHeader와 겹쳐져 Aside 오른쪽 테두리의 일부가 안 보는 버그 수정
   `,
   AsideInnerContainer: styled.section`
-    width: 250px;
+    width: 100%;
+    border-right: 0.05rem solid var(--color-gray08);
+    background-color: white;
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -214,26 +214,26 @@ const S = {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: 5px;
+    gap: 0.3rem;
   `,
   Nickname: styled.span`
     font-weight: bold;
   `,
   ProfileImg: styled.img`
-    width: 40px;
-    height: 40px;
-    border-radius: 9999px;
+    width: 2.5rem; // 40px
+    height: 2.5rem; // 40px
+    border-radius: var(--rounded-full);
     overflow: hidden;
     flex-shrink: 0;
     background-color: black;
   `,
 
   TabContainer: styled.section`
-    left: 80px;
+    left: 5rem;
     border-left: 1px solid var(--color-gray08);
     border-right: 1px solid var(--color-gray08);
     position: absolute;
-    width: 350px;
+    width: 22rem;
     height: 100%;
     background-color: white;
     font-weight: bold;
@@ -245,14 +245,14 @@ const S = {
   `,
   CloseTabButton: styled.button`
     position: absolute;
-    top: 0px;
-    right: 20px;
+    top: 0rem;
+    right: 1rem;
     color: var(--color-gray02);
   `,
   /*
   Backdrop: styled.section`
     position: absolute;
-    left: 80px;
+    left: 5rem;
     background-color: pink;
   `,
   */

--- a/client/src/components/Aside.tsx
+++ b/client/src/components/Aside.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import CommonStyles from '../styles/CommonStyles';
 import AsideButton from '../components/aside/AsideButton';
 import AsideLogo from '../components/aside/AsideLogo';
-import SvgBox from '../components/aside/SvgBox';
+import AsideProfileBox from '../components/aside/AsideProfileBox';
 
 import svgs from '../constants/svg';
 
@@ -77,7 +77,6 @@ export default function Aside(props: Props) {
                 )}
               </>
             )}
-
             <AsideButton leftIcon={svgs.ranking}>
               {isTabClosed && '명예의 전당'}
             </AsideButton>
@@ -92,18 +91,7 @@ export default function Aside(props: Props) {
         <S.Lower>
           {props.isLoggedIn ? (
             <>
-              <S.ProfileBox>
-                <S.ProfileLeftSection>
-                  <S.ProfileImg />
-                  <S.ProfileTexts>
-                    <S.Nickname>{isTabClosed && 'Waypil'}</S.Nickname>
-                    <span>{isTabClosed && '@waypil'}</span>
-                  </S.ProfileTexts>
-                </S.ProfileLeftSection>
-                <S.ProfileRightSection>
-                  <span>…</span>
-                </S.ProfileRightSection>
-              </S.ProfileBox>
+              <AsideProfileBox isTabClosed={isTabClosed} />
               {isTabClosed ? (
                 <S.SubmitBtn>글쓰기</S.SubmitBtn>
               ) : (
@@ -169,52 +157,6 @@ const S = {
   BookmarkedFaRecButton: styled.button`
     width: 100%;
     padding: 1rem 0rem;
-  `,
-  ProfileBox: styled.button`
-    width: 100%;
-    height: 3.25rem;
-    background-color: white;
-    padding-left: 1.25rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    &:hover {
-      filter: brightness(0.9);
-    }
-  `,
-  ProfileLeftSection: styled.section`
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    &:hover {
-      filter: brightness(0.9);
-    }
-  `,
-  ProfileRightSection: styled.section`
-    height: 100%;
-    padding-right: 1rem;
-    display: flex;
-    align-items: start;
-    justify-content: space-between;
-  `,
-  ProfileTexts: styled.section`
-    width: 100%;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    gap: 0.3rem;
-  `,
-  Nickname: styled.span`
-    font-weight: bold;
-  `,
-  ProfileImg: styled.img`
-    width: 2.5rem; // 40px
-    height: 2.5rem; // 40px
-    border-radius: var(--rounded-full);
-    overflow: hidden;
-    flex-shrink: 0;
-    background-color: black;
   `,
 
   TabContainer: styled.section`

--- a/client/src/components/HomeHeader.tsx
+++ b/client/src/components/HomeHeader.tsx
@@ -54,19 +54,17 @@ const S = {
     height: 75%;
     background-color: white;
     font-size: 1.25rem;
-    font-weight: bold;
-    color: ${(props) => props.isActive && 'var(--color-primary)'};
-    border-bottom: ${(props) =>
-      props.isActive
-        ? '3px solid var(--color-primary)'
-        : '3px solid transparent'};
+    font-weight: ${(props) => props.isActive && 'bold'};
+    color: var(--color-gray01);
+    border-bottom: 3px solid
+      ${(props) => (props.isActive ? 'var(--color-primary)' : 'transparent')};
 
     display: flex;
     justify-content: center;
     align-items: center;
 
     &:hover {
-      filter: brightness(0.9);
+      color: var(--color-primary);
     }
   `,
 };

--- a/client/src/components/HomeHeader.tsx
+++ b/client/src/components/HomeHeader.tsx
@@ -39,9 +39,9 @@ const S = {
   ...CommonStyles,
   HomeHeaderContainer: styled.header`
     position: fixed;
-    margin-left: var(--aside-w);
-    max-width: var(--header-max-w);
-    width: var(--header-w);
+    padding-left: var(--aside-w);
+    max-width: var(--app-max-w);
+    width: 100%;
     height: var(--header-h);
     background-color: white;
     // border: 1px solid;

--- a/client/src/components/HomeHeader.tsx
+++ b/client/src/components/HomeHeader.tsx
@@ -39,9 +39,10 @@ const S = {
   ...CommonStyles,
   HomeHeaderContainer: styled.header`
     position: fixed;
-    margin-left: 250px;
-    width: 890px;
-    height: 5rem;
+    margin-left: var(--aside-w);
+    max-width: var(--header-max-w);
+    width: var(--header-w);
+    height: var(--header-h);
     background-color: white;
     // border: 1px solid;
     display: flex;
@@ -52,7 +53,7 @@ const S = {
     width: 6rem;
     height: 75%;
     background-color: white;
-    font-size: 18px;
+    font-size: 1.25rem;
     font-weight: bold;
     color: ${(props) => props.isActive && 'var(--color-primary)'};
     border-bottom: ${(props) =>

--- a/client/src/components/aside/AsideButton.tsx
+++ b/client/src/components/aside/AsideButton.tsx
@@ -21,7 +21,7 @@ export default function AsideButton(props: Props) {
         <span>{props.children}</span>
       </S.AsideInnerButtonLeft>
       <S.AsideInnerButtonRight onClick={props.onClick || props.onClickRight}>
-        <SvgBox isReverse={props.isReverse}>{props.rightIcon || <></>}</SvgBox>
+        <SvgBox isReverse={!props.isReverse}>{props.rightIcon || <></>}</SvgBox>
       </S.AsideInnerButtonRight>
     </S.AsideButtonContainer>
   );

--- a/client/src/components/aside/AsideButton.tsx
+++ b/client/src/components/aside/AsideButton.tsx
@@ -18,21 +18,21 @@ export default function AsideButton(props: Props) {
     <S.AsideButtonContainer isSmall={props.isSmall}>
       <S.AsideInnerButtonLeft onClick={props.onClick}>
         <SvgBox>{props.leftIcon || <></>}</SvgBox>
-        <span>{props.children}</span>
+        {props.children ? <S.Text>{props.children}</S.Text> : <></>}
       </S.AsideInnerButtonLeft>
-      <S.AsideInnerButtonRight onClick={props.onClick || props.onClickRight}>
-        <SvgBox isReverse={!props.isReverse}>{props.rightIcon || <></>}</SvgBox>
-      </S.AsideInnerButtonRight>
+      {props.children && (
+        <S.AsideInnerButtonRight onClick={props.onClick || props.onClickRight}>
+          <SvgBox isReverse={!props.isReverse}>
+            {props.rightIcon || <></>}
+          </SvgBox>
+        </S.AsideInnerButtonRight>
+      )}
     </S.AsideButtonContainer>
   );
 }
 
-type AsideButtonContainerProps = {
-  isSmall?: boolean;
-};
-
 const S = {
-  AsideButtonContainer: styled.section<AsideButtonContainerProps>`
+  AsideButtonContainer: styled.div<{ isSmall?: boolean }>`
     width: 100%;
     height: ${(props) => (props.isSmall ? '2.75rem' : '3.25rem')};
     background-color: white;
@@ -52,6 +52,7 @@ const S = {
     align-items: center;
     gap: 0.5rem;
   `,
+  Text: styled.span``,
   AsideInnerButtonRight: styled.button`
     width: ${(props) => props.onClick && '3rem'};
     height: 100%;

--- a/client/src/components/aside/AsideLogo.tsx
+++ b/client/src/components/aside/AsideLogo.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+import SvgBox from '../aside/SvgBox';
+import svgs from '../../constants/svg';
+
+type Props = {
+  isTabClosed?: boolean;
+  children?: JSX.Element; // <svg>
+};
+
+export default function Logo(props: Props) {
+  return (
+    <S.LogoContainer isTabClosed={props.isTabClosed}>
+      <SvgBox>{svgs.logoSymbol}</SvgBox>
+      <span>{props.isTabClosed && svgs.logotext}</span>
+    </S.LogoContainer>
+  );
+}
+
+const S = {
+  LogoContainer: styled.button<{ isTabClosed: boolean | undefined }>`
+    width: 100%;
+    height: 3.25rem;
+    padding-left: 1rem;
+    margin: 2rem 0rem;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    & svg {
+      transform: scale(1.25);
+    }
+  `,
+  LogoSymbol: styled.button``,
+  LogoText: styled.button``,
+};

--- a/client/src/components/aside/AsideLogo.tsx
+++ b/client/src/components/aside/AsideLogo.tsx
@@ -30,6 +30,4 @@ const S = {
       transform: scale(1.25);
     }
   `,
-  LogoSymbol: styled.button``,
-  LogoText: styled.button``,
 };

--- a/client/src/components/aside/AsideProfileBox.tsx
+++ b/client/src/components/aside/AsideProfileBox.tsx
@@ -7,16 +7,16 @@ type Props = {
 export default function AsideProfileBox(props: Props) {
   return (
     <S.ProfileBoxContainer>
-      <S.ProfileLeftSection>
+      <S.ProfileLeftDiv>
         <S.ProfileImg />
         <S.ProfileTexts>
           <S.Nickname>{props.isTabClosed && 'Waypil'}</S.Nickname>
           <span>{props.isTabClosed && '@waypil'}</span>
         </S.ProfileTexts>
-      </S.ProfileLeftSection>
-      <S.ProfileRightSection>
-        <span>…</span>
-      </S.ProfileRightSection>
+      </S.ProfileLeftDiv>
+      <S.ProfileRightDiv>
+        {props.isTabClosed && <span>…</span>}
+      </S.ProfileRightDiv>
     </S.ProfileBoxContainer>
   );
 }
@@ -34,7 +34,7 @@ const S = {
       filter: brightness(0.9);
     }
   `,
-  ProfileLeftSection: styled.section`
+  ProfileLeftDiv: styled.div`
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -42,14 +42,14 @@ const S = {
       filter: brightness(0.9);
     }
   `,
-  ProfileRightSection: styled.section`
+  ProfileRightDiv: styled.div`
     height: 100%;
     padding-right: 1rem;
     display: flex;
     align-items: start;
     justify-content: space-between;
   `,
-  ProfileTexts: styled.section`
+  ProfileTexts: styled.div`
     width: 100%;
     height: 100%;
     display: flex;

--- a/client/src/components/aside/AsideProfileBox.tsx
+++ b/client/src/components/aside/AsideProfileBox.tsx
@@ -1,0 +1,71 @@
+import styled from '@emotion/styled';
+
+type Props = {
+  isTabClosed?: boolean;
+};
+
+export default function AsideProfileBox(props: Props) {
+  return (
+    <S.ProfileBoxContainer>
+      <S.ProfileLeftSection>
+        <S.ProfileImg />
+        <S.ProfileTexts>
+          <S.Nickname>{props.isTabClosed && 'Waypil'}</S.Nickname>
+          <span>{props.isTabClosed && '@waypil'}</span>
+        </S.ProfileTexts>
+      </S.ProfileLeftSection>
+      <S.ProfileRightSection>
+        <span>…</span>
+      </S.ProfileRightSection>
+    </S.ProfileBoxContainer>
+  );
+}
+
+const S = {
+  ProfileBoxContainer: styled.button`
+    width: 100%;
+    height: 3.25rem;
+    background-color: white;
+    padding-left: 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    &:hover {
+      filter: brightness(0.9);
+    }
+  `,
+  ProfileLeftSection: styled.section`
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    &:hover {
+      filter: brightness(0.9);
+    }
+  `,
+  ProfileRightSection: styled.section`
+    height: 100%;
+    padding-right: 1rem;
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+  `,
+  ProfileTexts: styled.section`
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.3rem;
+  `,
+  Nickname: styled.span`
+    font-weight: bold;
+  `,
+  ProfileImg: styled.img`
+    width: 2.5rem; // 40px
+    height: 2.5rem; // 40px
+    border-radius: var(--rounded-full);
+    overflow: hidden;
+    flex-shrink: 0;
+    background-color: black;
+  `,
+};

--- a/client/src/components/aside/SvgBox.tsx
+++ b/client/src/components/aside/SvgBox.tsx
@@ -20,12 +20,13 @@ type SvgContainerProps = {
 };
 
 const S = {
-  SvgContainer: styled.section<SvgContainerProps>`
+  SvgContainer: styled.div<SvgContainerProps>`
     width: 3rem;
     height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
+    flex-shrink: 0;
     transform: ${(props) =>
       props.isReverse ? 'rotate(180deg)' : 'rotate(0deg)'};
   `,

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -71,7 +71,7 @@ const S = {
   `,
 
   AppContainer: styled.div`
-    max-width: 1140px;
+    max-width: var(--app-max-w);
     width: 100%;
     display: flex;
   `,
@@ -92,10 +92,11 @@ const S = {
     isShowHeader: boolean;
     bgColor?: string;
   }>`
-    height: 100%;
+    width: auto;
+    height: calc(100% - var(--header-h));
     background-color: ${(props) => props.bgColor || 'transparent'};
     margin-top: ${(props) => props.isShowHeader && '5rem'};
-    margin-left: ${(props) => props.isShowNav && '250px'}; // <Aside> width
+    margin-left: ${(props) => props.isShowNav && 'var(--aside-w)'};
     display: flex;
     flex-direction: column;
   `,

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -39,15 +39,11 @@ const App = ({ Component, pageProps }: AppProps) => {
         <GlobalStyles />
         <S.RootScreen>
           <S.AppContainer>
-            <S.FlexPage>
+            <S.FlexPage bgColor={bgColor}>
               {isShowNav && <Aside isLoggedIn={true} />}
               <S.SubPage>
                 {isShowHeader && <HomeHeader />}
-                <S.Main
-                  isShowNav={isShowNav}
-                  isShowHeader={isShowHeader}
-                  bgColor={bgColor}
-                >
+                <S.Main isShowNav={isShowNav} isShowHeader={isShowHeader}>
                   <Component {...pageProps} />
                 </S.Main>
               </S.SubPage>
@@ -76,9 +72,10 @@ const S = {
     display: flex;
   `,
 
-  FlexPage: styled.div`
+  FlexPage: styled.div<{ bgColor?: string }>`
     width: 100%;
     height: 100%;
+    background-color: ${(props) => props.bgColor || 'transparent'};
     display: flex;
   `,
 
@@ -87,14 +84,9 @@ const S = {
     height: 100%;
   `,
 
-  Main: styled.main<{
-    isShowNav: boolean;
-    isShowHeader: boolean;
-    bgColor?: string;
-  }>`
+  Main: styled.main<{ isShowNav: boolean; isShowHeader: boolean }>`
     width: auto;
     height: calc(100% - var(--header-h));
-    background-color: ${(props) => props.bgColor || 'transparent'};
     margin-top: ${(props) => props.isShowHeader && '5rem'};
     margin-left: ${(props) => props.isShowNav && 'var(--aside-w)'};
     display: flex;

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -42,7 +42,15 @@ const GlobalStyles = () => (
 
         /* border-radius */
         --rounded-default: 0.625rem;
+        --rounded-full: 999rem;
 
+        /* width & height */
+        --app-max-w: 1140px;
+        --aside-w : 15.5rem;  // 15rem~15.625rem
+        --header-max-w : calc(var(--app-max-w) - var(--aside-w));
+        --header-w : calc(100vw - var(--aside-w));
+        --header-h : 5rem;
+        --main-w : calc(var(--app-max-w) - var(--aside-w));
       }
 
       li {

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -47,8 +47,7 @@ const GlobalStyles = () => (
         /* width & height */
         --app-max-w: 1140px;
         --aside-w : 15.5rem;  // 15rem~15.625rem
-        --header-max-w : calc(var(--app-max-w) - var(--aside-w));
-        --header-w : calc(100vw - var(--aside-w));
+        --aside-tab-w: 22rem;
         --header-h : 5rem;
         --main-w : calc(var(--app-max-w) - var(--aside-w));
       }


### PR DESCRIPTION
# [FE] designsemantic-109: `<HomeHeader>`, `<Aside>` 디자인/시맨틱 개선

> 🚨 주의! `trunk`로의 다이렉트 Merge입니다.

<br/>

## 구현한 기능 & 변경 내역

- design: Tab 펼칠 시 슬라이드 애니메이션 구현
- design: `<HomeHeader>`에 반응형 적용
  - (오른쪽 영역 기준) 확대/축소해도 항상 가운데에 있도록 배치
- design: `<HomeHeader>`에 스타일 개선안 적용
  * [미선택]: 폰트: 진회색 | border-bottom: transparent
  * [hover]: 폰트: --color-primary
  * [selected]: 폰트: bold | border-bottom: --color-primary
- fix: 드롭다운 아이콘이 상하 반대로 되어 있는 버그 수정
- chore: `<section>` → `<div>`
- chore: `<ProfileBox>` .tsx로 독립

<br/>

## 추후 개선 사항
* 웹 접근성 적용
* `<button type='button'>` 적용
* `<Aside>`에도 반응형 적용
* Tab이 열려서 `<Aside>`가 축소될 때에도 애니메이션 적용

<br/>

## 비고
반응형에 애니메이션에… 디자인 개선하는 부분이 생각보다 시간이 많이 들어가네요…
오늘 하루 부족함을 많이 느꼈습니다 😔