### PR TITLE
[FE] ImgCrop-104 : img crop component & hook 

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,6 +16,7 @@
         "next": "^13.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-easy-crop": "^5.0.0",
         "react-redux": "^8.1.1"
       },
       "devDependencies": {
@@ -4284,6 +4285,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA=="
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4779,6 +4785,24 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.0.0.tgz",
+      "integrity": "sha512-ppYg3E0jxpDW+HdgLa65lCykZSsGMuusBuKD3HeTMs/Aod4xiWyAH5jZn5iHlllLUV2c0PPT6FznvdNeLhO2wA==",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
+      }
+    },
+    "node_modules/react-easy-crop/node_modules/tslib": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "next": "^13.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-easy-crop": "^5.0.0",
     "react-redux": "^8.1.1"
   },
   "devDependencies": {

--- a/client/src/components/img-crop/ImgCropModal.tsx
+++ b/client/src/components/img-crop/ImgCropModal.tsx
@@ -1,0 +1,158 @@
+import styled from '@emotion/styled';
+import { useState, useCallback, useEffect } from 'react';
+import Cropper from 'react-easy-crop';
+import { Area, Point } from 'react-easy-crop/types';
+import { getCroppedImg } from './canvasUtils';
+import CommonStyles from '../../styles/CommonStyles';
+
+interface ImageCropModalProps {
+  imgSrc: string | null;
+  onCropComplete: (image: string | null) => void;
+  isOpen: boolean;
+  setCropModal: (isOpen: boolean) => void;
+  aspect: number;
+  cropShape: 'round' | 'rect';
+}
+
+function ImgCropModal({
+  isOpen,
+  imgSrc,
+  onCropComplete,
+  setCropModal,
+  aspect,
+  cropShape,
+}: ImageCropModalProps) {
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+
+  const handleCropComplete = useCallback(
+    (croppedArea: Area, croppedAreaPixels: Area) => {
+      setCroppedAreaPixels(croppedAreaPixels);
+    },
+    []
+  );
+
+  const showCroppedImage = useCallback(async () => {
+    try {
+      if (imgSrc && croppedAreaPixels) {
+        const croppedImage = await getCroppedImg(imgSrc, croppedAreaPixels);
+        if (typeof croppedImage === 'string') {
+          onCropComplete(croppedImage);
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setCropModal(false);
+    }
+  }, [imgSrc, croppedAreaPixels, onCropComplete]);
+
+  // esc 눌렀을 때 modal close
+  useEffect(() => {
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setCropModal(false);
+      }
+    };
+
+    window.addEventListener('keyup', handleKeyUp);
+
+    return () => {
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, []);
+
+  const handleCropChange = useCallback((newCrop: Point) => {
+    setCrop(newCrop);
+  }, []);
+
+  const handleZoomChange = useCallback((newZoom: number) => {
+    setZoom(newZoom);
+  }, []);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <S.CropContainer>
+      <Cropper
+        image={imgSrc || ''}
+        crop={crop}
+        zoom={zoom}
+        aspect={aspect}
+        onCropChange={handleCropChange}
+        onCropComplete={handleCropComplete}
+        onZoomChange={handleZoomChange}
+        cropShape={cropShape}
+      />
+      <S.ButtonWrap>
+        <button type='button' onClick={showCroppedImage}>
+          선택
+        </button>
+        <button onClick={() => setCropModal(false)}>취소</button>
+      </S.ButtonWrap>
+    </S.CropContainer>
+  );
+}
+
+const S = {
+  ...CommonStyles,
+  CropContainer: styled.div`
+    max-width: 400px;
+    width: 100%;
+    height: 300px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--color-white);
+    padding: 1rem;
+    border-radius: var(--rounded-default);
+    box-shadow: var(--box-shadow-default);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    & > div:nth-of-type(1) {
+      position: relative !important;
+      display: block;
+      width: 100%;
+      height: calc(100% - 2rem);
+      margin-bottom: 1rem;
+      border-radius: var(--rounded-default);
+    }
+  `,
+  ButtonWrap: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    & > button {
+      width: 90px;
+      text-align: center;
+      color: var(--color-white);
+      padding: 0.75rem;
+      background: var(--color-primary);
+      border-radius: 100px;
+      border: 2px solid var(--color-primary);
+      &:hover {
+        background: var(--color-white);
+        font-weight: 600;
+        color: var(--color-primary);
+      }
+    }
+
+    & > button:nth-of-type(2) {
+      border: 2px solid var(--color-point-lilac);
+      background: var(--color-point-lilac);
+      margin-left: 1rem;
+      &:hover {
+        background: var(--color-white);
+        color: var(--color-point-lilac);
+      }
+    }
+  `,
+};
+
+export default ImgCropModal;

--- a/client/src/components/img-crop/canvasUtils.ts
+++ b/client/src/components/img-crop/canvasUtils.ts
@@ -1,0 +1,154 @@
+/** react-easy-crop 라이브러리에서 제공하는 함수 */
+
+type ImageSrc = string;
+
+interface Crop {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export const createImage = (url: ImageSrc): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', (error) => reject(error));
+    image.setAttribute('crossOrigin', 'anonymous'); // needed to avoid cross-origin issues on CodeSandbox
+    image.src = url;
+  });
+
+export function getRadianAngle(degreeValue: number): number {
+  return (degreeValue * Math.PI) / 180;
+}
+
+/**
+ * Returns the new bounding area of a rotated rectangle.
+ */
+export function rotateSize(width: number, height: number, rotation: number) {
+  const rotRad = getRadianAngle(rotation);
+
+  return {
+    width:
+      Math.abs(Math.cos(rotRad) * width) + Math.abs(Math.sin(rotRad) * height),
+    height:
+      Math.abs(Math.sin(rotRad) * width) + Math.abs(Math.cos(rotRad) * height),
+  };
+}
+
+/**
+ * This function was adapted from the one in the ReadMe of https://github.com/DominicTobias/react-image-crop
+ */
+/**
+ * This function was adapted from the one in the ReadMe of https://github.com/DominicTobias/react-image-crop
+ */
+export async function getCroppedImg(
+  imageSrc: ImageSrc,
+  pixelCrop: Crop,
+  rotation = 0,
+  flip = { horizontal: false, vertical: false }
+) {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('Unable to create 2D context.');
+  }
+
+  const rotRad = getRadianAngle(rotation);
+
+  // calculate bounding box of the rotated image
+  const { width: bBoxWidth, height: bBoxHeight } = rotateSize(
+    image.width,
+    image.height,
+    rotation
+  );
+
+  // set canvas size to match the bounding box
+  canvas.width = bBoxWidth;
+  canvas.height = bBoxHeight;
+
+  // translate canvas context to a central location to allow rotating and flipping around the center
+  ctx.translate(bBoxWidth / 2, bBoxHeight / 2);
+  ctx.rotate(rotRad);
+  ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1);
+  ctx.translate(-image.width / 2, -image.height / 2);
+
+  // draw rotated image
+  ctx.drawImage(image, 0, 0);
+
+  const croppedCanvas = document.createElement('canvas');
+
+  const croppedCtx = croppedCanvas.getContext('2d');
+
+  if (!croppedCtx) {
+    return null;
+  }
+
+  // Set the size of the cropped canvas
+  croppedCanvas.width = pixelCrop.width;
+  croppedCanvas.height = pixelCrop.height;
+
+  // Draw the cropped image onto the new canvas
+  croppedCtx.drawImage(
+    canvas,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    pixelCrop.width,
+    pixelCrop.height
+  );
+
+  // As Base64 string
+  // return croppedCanvas.toDataURL('image/jpeg');
+
+  // As a blob
+  return new Promise((resolve, reject) => {
+    croppedCanvas.toBlob((file: Blob | null) => {
+      if (file) {
+        resolve(URL.createObjectURL(file));
+      } else {
+        reject(new Error('Blob creation failed.'));
+      }
+    }, 'image/jpeg');
+  });
+}
+
+export async function getRotatedImage(imageSrc: ImageSrc, rotation = 0) {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('Unable to create 2D context.');
+  }
+
+  const orientationChanged =
+    rotation === 90 ||
+    rotation === -90 ||
+    rotation === 270 ||
+    rotation === -270;
+  if (orientationChanged) {
+    canvas.width = image.height;
+    canvas.height = image.width;
+  } else {
+    canvas.width = image.width;
+    canvas.height = image.height;
+  }
+
+  ctx.translate(canvas.width / 2, canvas.height / 2);
+  ctx.rotate((rotation * Math.PI) / 180);
+  ctx.drawImage(image, -image.width / 2, -image.height / 2);
+
+  return new Promise((resolve) => {
+    canvas.toBlob((file: Blob | null) => {
+      if (file) {
+        resolve(URL.createObjectURL(file));
+      }
+    }, 'image/png');
+  });
+}

--- a/client/src/components/img-crop/imgCropUtils.ts
+++ b/client/src/components/img-crop/imgCropUtils.ts
@@ -1,0 +1,34 @@
+export function readFile(file: File): Promise<string> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.addEventListener(
+      'load',
+      () => {
+        if (typeof reader.result === 'string') {
+          resolve(reader.result);
+        }
+      },
+      false
+    );
+    reader.readAsDataURL(file);
+  });
+}
+
+interface HandleFileChangeProps {
+  e: React.ChangeEvent<HTMLInputElement>;
+  setCropModal: (value: boolean) => void;
+  setImgSrc: (value: string | null) => void;
+}
+
+export const handleFileChange = async ({
+  e,
+  setCropModal,
+  setImgSrc,
+}: HandleFileChangeProps): Promise<void> => {
+  if (e.target.files && e.target.files.length > 0) {
+    const file = e.target.files[0];
+    const imageDataUrl = await readFile(file);
+    setCropModal(true);
+    setImgSrc(imageDataUrl);
+  }
+};

--- a/client/src/hooks/useImageCrop.tsx
+++ b/client/src/hooks/useImageCrop.tsx
@@ -1,0 +1,49 @@
+import { useState, useCallback } from 'react';
+import { Area, Point } from 'react-easy-crop/types';
+import { getCroppedImg } from '../components/img-crop/canvasUtils';
+
+export function useImageCrop() {
+  const [imgSrc, setImgSrc] = useState<string | null>(null);
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [croppedImage, setCroppedImage] = useState<string | null>(null);
+  const [cropModal, setCropModal] = useState(false);
+
+  const onCropComplete = useCallback(
+    (croppedArea: Area, croppedAreaPixels: Area) => {
+      setCroppedAreaPixels(croppedAreaPixels);
+    },
+    []
+  );
+
+  const showCroppedImage = useCallback(async () => {
+    try {
+      if (imgSrc && croppedAreaPixels) {
+        const croppedImage = await getCroppedImg(imgSrc, croppedAreaPixels);
+        if (typeof croppedImage === 'string') {
+          setCroppedImage(croppedImage);
+        }
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }, [imgSrc, croppedAreaPixels]);
+
+  return {
+    imgSrc,
+    setImgSrc,
+    crop,
+    setCrop,
+    zoom,
+    setZoom,
+    croppedAreaPixels,
+    setCroppedAreaPixels,
+    croppedImage,
+    setCroppedImage,
+    onCropComplete,
+    showCroppedImage,
+    cropModal,
+    setCropModal,
+  };
+}

--- a/client/src/hooks/useImgCrop.tsx
+++ b/client/src/hooks/useImgCrop.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { Area, Point } from 'react-easy-crop/types';
 import { getCroppedImg } from '../components/img-crop/canvasUtils';
 
-export function useImageCrop() {
+export function useImgCrop() {
   const [imgSrc, setImgSrc] = useState<string | null>(null);
   const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);

--- a/client/src/pages/crop-test/index.tsx
+++ b/client/src/pages/crop-test/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useImgCrop } from '../../hooks/useImgCrop';
 import { handleFileChange } from '../../components/img-crop/imgCropUtils';
 import ImgCropModal from '../../components/img-crop/ImgCropModal';
@@ -36,7 +35,7 @@ export default function index() {
         />
       )}
       <S.ImgBox>
-        <img src={croppedImage} alt='' />
+        <img src={croppedImage || ''} alt='' />
       </S.ImgBox>
     </div>
   );

--- a/client/src/pages/crop-test/index.tsx
+++ b/client/src/pages/crop-test/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useImgCrop } from '../../hooks/useImgCrop';
+import { handleFileChange } from '../../components/img-crop/imgCropUtils';
+import ImgCropModal from '../../components/img-crop/ImgCropModal';
+import styled from '@emotion/styled';
+
+export default function index() {
+  const {
+    imgSrc,
+    setImgSrc,
+    croppedImage,
+    setCroppedImage,
+    cropModal,
+    setCropModal,
+  } = useImgCrop();
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    await handleFileChange({
+      e,
+      setCropModal,
+      setImgSrc,
+    });
+  };
+
+  return (
+    <div>
+      <input type='file' onChange={onFileChange} />
+      {cropModal && (
+        <ImgCropModal
+          isOpen={cropModal}
+          setCropModal={setCropModal}
+          imgSrc={imgSrc}
+          aspect={1 / 1} // 1 / 1은 화면 비율입니다. 원하시는 비율에 맞춰 수정 가능합니다.
+          cropShape='round' // cropShape는 'round' 또는 'rect'만 선택 가능합니다.
+          onCropComplete={(image) => setCroppedImage(image)}
+        />
+      )}
+      <S.ImgBox>
+        <img src={croppedImage} alt='' />
+      </S.ImgBox>
+    </div>
+  );
+}
+
+const S = {
+  ImgBox: styled.div`
+    width: 400px;
+    height: 400px;
+    overflow: hidden;
+    border-radius: 100%;
+    border: 1px solid #333;
+    background: white;
+
+    & > img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  `,
+};


### PR DESCRIPTION
# ImgCrop-104 : img crop component & hook 
![Jul-08-2023 18-29-48](https://github.com/codestates-seb/seb44_main_016/assets/121333344/3c9b5180-6a80-448e-a212-fe0dfcebdd5b)



<br/>

## 구현한 기능
1. 이미지 크롭 컴포넌트 작성
2. 이미지 크롭 hooks 작성

<br/>

## 테스트 URL 
+ 위 GIF에 나오는 UI는 아직 merge 되지 않아 test page 작성 후 링크 첨부합니다.
사용시 해당 페이지 참고 바랍니다. 
https://zerohip-git-imgcrop-104-everland.vercel.app/crop-test


## 사용법
재사용성을 높이기 위해 hooks를 만들어 crop component를 작성했고 사용하고자 하는 컴포넌트, 페이지에서 불러와야합니다. 

```ts
// 컴포넌트와 util 함수를 불러옵니다.

import { useImgCrop } from '../../hooks/useImgCrop';
import { handleFileChange } from '../../components/img-crop/imgCropUtils';
import ImgCropModal from '../../components/img-crop/ImgCropModal';

// useImgCrop hook을 불러옵니다. 
  const {
    imgSrc,
    setImgSrc,
    croppedImage,
    setCroppedImage,
    cropModal,
    setCropModal,
  } = useImgCrop();

// 파일을 crop img로 변경해주는 함수 
  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
    await handleFileChange({
      e,
      setCropModal,
      setImgSrc,
    });
  };


// 컴포넌트 불러오는 곳에서 아래와 같이 작성해줍니다.

  <input type='file' onChange={onFileChange} />
  {cropModal && (
    <ImgCropModal
      isOpen={cropModal}
      setCropModal={setCropModal}
      imgSrc={imgSrc}
      aspect={1 / 1} // 1 / 1은 화면 비율입니다. 원하시는 비율에 맞춰 수정 가능합니다.
      cropShape='round' // cropShape는 'round' 또는 'rect'만 선택 가능합니다.
      onCropComplete={(image) => setCroppedImage(image)}
    />
  )}



```
