### PR TITLE
[FE] !HOTFIX: 모든 페이지에 `<Header>`가 뜨는 버그 수정

### DIFF
--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -16,7 +16,7 @@ const App = ({ Component, pageProps }: AppProps) => {
   let isShowNav = true;
   let isShowHeader = false;
   let bgColor = '#F0F3F8';
-  if (router.pathname.startsWith('/')) {
+  if (router.pathname === '/') {
     isShowHeader = true;
   } else if (router.pathname.startsWith('/user')) {
     isShowNav = false;


### PR DESCRIPTION
# !HOTFIX: 모든 페이지에 `<Header>`가 뜨는 버그 수정

## 원인
isShowHeader가 true가 되는 조건이 `router.pathname.startsWith('/')`인데, 이러면 모든 페이지(모든 라우팅 경로)에 헤더가 생성되고 만다

## 해결책 및 수정 사항
`router.pathname === '/'`로 변경. Home 페이지에만 헤더가 뜨도록 설정 (테스트 완료)
