### PR TITLE
[FE] blind-121 : feat :visual hidden css 추가

### DIFF
--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -107,7 +107,17 @@ const GlobalStyles = () => (
         border: none;
       }
 
-      
+      .blind {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        border: 0;
+        margin: -1px;
+        padding:0;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%); 
+        overflow: hidden;
+      }
     `}
   />
 );


### PR DESCRIPTION
# feat :visual hidden css 추가

![image](https://github.com/codestates-seb/seb44_main_016/assets/121333344/79fd76b4-c69f-4f4a-85fa-603a432fabe3)

<br/>

## 구현한 기능
1. 웹접근성을 위한 visual hidden css를 사용할 수 있는 클래스를 추가하였습니다.

<br/>

## 비고
디자인상 제목 태그가 없을 경우, 스크린 리더기 사용자들은 불편을 겪을 수 밖에 없습니다. 디자인상 불필요하여 가리게 될 경우 visual hidden css 클래스명을 사용하여 웹 접근성을 지킬 수 있습니다. 

## URL 생략