### PR TITLE
[FE] crop-150: img crop modal 검정색 배경 추가

### DIFF
--- a/client/src/components/img-crop/ImgCropModal.tsx
+++ b/client/src/components/img-crop/ImgCropModal.tsx
@@ -111,6 +111,7 @@ const S = {
     display: grid;
     place-items: center;
     background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(5px);
   `,
   CropContainer: styled.div`
     max-width: 400px;

--- a/client/src/components/img-crop/ImgCropModal.tsx
+++ b/client/src/components/img-crop/ImgCropModal.tsx
@@ -76,37 +76,46 @@ function ImgCropModal({
   }
 
   return (
-    <S.CropContainer>
-      <Cropper
-        image={imgSrc || ''}
-        crop={crop}
-        zoom={zoom}
-        aspect={aspect}
-        onCropChange={handleCropChange}
-        onCropComplete={handleCropComplete}
-        onZoomChange={handleZoomChange}
-        cropShape={cropShape}
-      />
-      <S.ButtonWrap>
-        <button type='button' onClick={showCroppedImage}>
-          선택
-        </button>
-        <button onClick={() => setCropModal(false)}>취소</button>
-      </S.ButtonWrap>
-    </S.CropContainer>
+    <S.CropWrap>
+      <S.CropContainer>
+        <Cropper
+          image={imgSrc || ''}
+          crop={crop}
+          zoom={zoom}
+          aspect={aspect}
+          onCropChange={handleCropChange}
+          onCropComplete={handleCropComplete}
+          onZoomChange={handleZoomChange}
+          cropShape={cropShape}
+        />
+        <S.ButtonWrap>
+          <button type='button' onClick={showCroppedImage}>
+            선택
+          </button>
+          <button onClick={() => setCropModal(false)}>취소</button>
+        </S.ButtonWrap>
+      </S.CropContainer>
+    </S.CropWrap>
   );
 }
 
 const S = {
   ...CommonStyles,
+  CropWrap: styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    display: grid;
+    place-items: center;
+    background: rgba(0, 0, 0, 0.4);
+  `,
   CropContainer: styled.div`
     max-width: 400px;
     width: 100%;
     height: 300px;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     background: var(--color-white);
     padding: 1rem;
     border-radius: var(--rounded-default);
@@ -115,6 +124,7 @@ const S = {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    z-index: 2;
     & > div:nth-of-type(1) {
       position: relative !important;
       display: block;

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -96,7 +96,6 @@ const GlobalStyles = () => (
         cursor: pointer;
         background: none;
         border: none;
-        outline: none;
         font-size: inherit;
         font-weight: inherit;
         font-family: inherit;


### PR DESCRIPTION
# img crop modal 검정색 배경 추가

![image](https://github.com/codestates-seb/seb44_main_016/assets/121333344/ba034851-d934-4b90-b306-8b1ab417e8a0)

![image](https://github.com/codestates-seb/seb44_main_016/assets/121333344/5e561e44-8829-46b6-ab2f-5e4448694f77)


<br/>

## 구현한 기능
1. img crop modal 컴포넌트에 배경색을 깔아주어 컴포넌트 구별을 쉽게 할 수 있도록 변경하였습니다.
2. 버튼이 tab이 될 때 outline이 표시되지 않아 탭 위치를 알아볼 수 없던 것을 수정하였습니다. (웹접근 필수사항)

<br/>
