### PR TITLE
[FE] buttonStyle:-156 : Button style color props 추가 및 Link 태그 디자인 추가

### DIFF
--- a/client/src/pages/crop-test/index.tsx
+++ b/client/src/pages/crop-test/index.tsx
@@ -4,6 +4,7 @@ import ImgCropModal from '../../components/img-crop/ImgCropModal';
 import styled from '@emotion/styled';
 import FilePlusLabel from '../../components/FilePlusLabel';
 import CommonStyles from '../../styles/CommonStyles';
+import Link from 'next/link';
 
 export default function index() {
   const {
@@ -39,11 +40,19 @@ export default function index() {
       <S.ImgBox>
         <img src={croppedImage || ''} alt='' />
       </S.ImgBox>
-      <S.SubmitBtn color='--color-point-blue'>버튼</S.SubmitBtn>
+      <S.SubmitBtn color='--color-point-blue' small>
+        버튼
+      </S.SubmitBtn>
       <S.SubmitBtn color='--color-point-red'>버튼</S.SubmitBtn>
       <S.SubmitBtn color='--color-point-yellow'>버튼</S.SubmitBtn>
       <S.SubmitBtn color='--color-point-lilac'>버튼</S.SubmitBtn>
       <S.Textarea placeholder='123' />
+      <S.LinkBtn href='/' color='--color-point-red'>
+        이동
+      </S.LinkBtn>
+      <S.LinkBtn href='/' small>
+        이동
+      </S.LinkBtn>
     </div>
   );
 }

--- a/client/src/pages/crop-test/index.tsx
+++ b/client/src/pages/crop-test/index.tsx
@@ -3,6 +3,7 @@ import { handleFileChange } from '../../components/img-crop/imgCropUtils';
 import ImgCropModal from '../../components/img-crop/ImgCropModal';
 import styled from '@emotion/styled';
 import FilePlusLabel from '../../components/FilePlusLabel';
+import CommonStyles from '../../styles/CommonStyles';
 
 export default function index() {
   const {
@@ -38,11 +39,17 @@ export default function index() {
       <S.ImgBox>
         <img src={croppedImage || ''} alt='' />
       </S.ImgBox>
+      <S.SubmitBtn color='--color-point-blue'>버튼</S.SubmitBtn>
+      <S.SubmitBtn color='--color-point-red'>버튼</S.SubmitBtn>
+      <S.SubmitBtn color='--color-point-yellow'>버튼</S.SubmitBtn>
+      <S.SubmitBtn color='--color-point-lilac'>버튼</S.SubmitBtn>
+      <S.Textarea placeholder='123' />
     </div>
   );
 }
 
 const S = {
+  ...CommonStyles,
   ImgBox: styled.div`
     width: 400px;
     height: 400px;

--- a/client/src/pages/crop-test/index.tsx
+++ b/client/src/pages/crop-test/index.tsx
@@ -40,19 +40,6 @@ export default function index() {
       <S.ImgBox>
         <img src={croppedImage || ''} alt='' />
       </S.ImgBox>
-      <S.SubmitBtn color='--color-point-blue' small>
-        버튼
-      </S.SubmitBtn>
-      <S.SubmitBtn color='--color-point-red'>버튼</S.SubmitBtn>
-      <S.SubmitBtn color='--color-point-yellow'>버튼</S.SubmitBtn>
-      <S.SubmitBtn color='--color-point-lilac'>버튼</S.SubmitBtn>
-      <S.Textarea placeholder='123' />
-      <S.LinkBtn href='/' color='--color-point-red'>
-        이동
-      </S.LinkBtn>
-      <S.LinkBtn href='/' small>
-        이동
-      </S.LinkBtn>
     </div>
   );
 }

--- a/client/src/styles/CommonStyles.tsx
+++ b/client/src/styles/CommonStyles.tsx
@@ -3,23 +3,34 @@ import styled from '@emotion/styled';
 interface ButtonProps {
   small?: boolean;
   large?: boolean;
+  color?: string;
 }
 
 const CommonStyles = {
   SubmitBtn: styled.button<ButtonProps>`
     position: relative;
     display: inline-block;
-    color: var(--color-white);
+    color: ${(props) =>
+      props.color === '--color-point-lilac'
+        ? `var(--color-black)`
+        : `var(--color-white)`};
     padding: 1rem;
     border-radius: 100px;
     font-weight: 400;
-    border: 2px solid var(--color-primary);
+    border: 2px solid
+      ${(props) =>
+        props.color ? `var(${props.color})` : `var(--color-primary)`};
     overflow: hidden;
     background-color: white;
     z-index: 1;
 
     &:hover {
-      color: var(--color-primary);
+      color: ${(props) =>
+        props.color === '--color-point-lilac'
+          ? `var(--color-black)`
+          : props.color
+          ? `var(${props.color})`
+          : `var(--color-primary)`};
       background-color: white;
       transition-duration: 0.7s;
       font-weight: 700;
@@ -33,7 +44,8 @@ const CommonStyles = {
       left: -4rem;
       z-index: -1;
       border-radius: 100%;
-      background: var(--color-primary);
+      background: ${(props) =>
+        props.color ? `var(${props.color})` : `var(--color-primary)`};
       transition: 0.7s;
     }
 

--- a/client/src/styles/CommonStyles.tsx
+++ b/client/src/styles/CommonStyles.tsx
@@ -1,13 +1,14 @@
 import styled from '@emotion/styled';
+import Link from 'next/link';
 
-interface ButtonProps {
+interface Props {
   small?: boolean;
   large?: boolean;
   color?: string;
 }
 
 const CommonStyles = {
-  SubmitBtn: styled.button<ButtonProps>`
+  SubmitBtn: styled.button<Props>`
     position: relative;
     display: inline-block;
     color: ${(props) =>
@@ -23,6 +24,95 @@ const CommonStyles = {
     overflow: hidden;
     background-color: white;
     z-index: 1;
+
+    &:hover {
+      color: ${(props) =>
+        props.color === '--color-point-lilac'
+          ? `var(--color-black)`
+          : props.color
+          ? `var(${props.color})`
+          : `var(--color-primary)`};
+      background-color: white;
+      transition-duration: 0.7s;
+      font-weight: 700;
+    }
+    &::before {
+      content: '';
+      position: absolute;
+      width: 20rem;
+      height: 20rem;
+      top: -4rem;
+      left: -4rem;
+      z-index: -1;
+      border-radius: 100%;
+      background: ${(props) =>
+        props.color ? `var(${props.color})` : `var(--color-primary)`};
+      transition: 0.7s;
+    }
+
+    &:hover::before {
+      top: 2.5rem;
+      left: 2.5rem;
+    }
+    ${({ small }) =>
+      small &&
+      `
+    width: auto;
+    padding: 0.68rem 1.125rem;
+    &::before {
+        width: 8rem;
+        height: 8rem;
+        top:-1.6rem;
+        left:-1.6rem;
+      }
+    &:hover::before{
+      top: 4rem;
+      left: 4rem;
+    }
+  `}
+
+    ${({ large }) =>
+      large &&
+      `
+    width: 100%;
+    max-width: 40rem;
+    &::before {
+        width: 80rem;
+        height: 80rem;
+        top:-16rem;
+        left:-16rem;
+      }
+
+      &:hover::before{
+        top: 10rem;
+        left: 10rem;
+      }
+  `}
+  
+  ${({ small, large }) =>
+      !small &&
+      !large &&
+      `
+    width: 10rem;
+  `}
+  `,
+  LinkBtn: styled(Link)<Props>`
+    position: relative;
+    display: inline-block;
+    color: ${(props) =>
+      props.color === '--color-point-lilac'
+        ? `var(--color-black)`
+        : `var(--color-white)`};
+    padding: 1rem;
+    border-radius: 100px;
+    font-weight: 400;
+    border: 2px solid
+      ${(props) =>
+        props.color ? `var(${props.color})` : `var(--color-primary)`};
+    overflow: hidden;
+    background-color: white;
+    z-index: 1;
+    text-align: center;
 
     &:hover {
       color: ${(props) =>

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -15,15 +15,27 @@ const GlobalStyles = () => (
         color: #333;
         font-family: 'Pretendard';
         font-weight: 400;
+        overflow: overlay;
+        overflow-x: hidden;
 
 
         /* color */
         --color-primary : #676FC6;
+        --color-primary-hover : #858cdc;
+        --color-point-purple: #7f7ad9;
         --color-point-red : #FF451A;
+        --color-point-pink-red: #ee5353;
+        --color-point-pink : #d95784;
         --color-point-blue : #537FEE;
         --color-point-yellow : #F8AC19;
         --color-point-lilac : #C2C5E8;
+        --color-point-light-blue: #a8aece;
+        --color-point-gray: #a4a7b5;
+        --color-point-light-gray: #D6D6D6;
         --color-white : #FFF;
+        --color-black: #000;
+
+        --color-error-red: #df0c0c;
 
         --color-gray01 : #333;
         --color-gray02 : #4D4D4D;
@@ -36,6 +48,15 @@ const GlobalStyles = () => (
         --color-gray09 : #F6F6F6;
 
         --color-border-gray : #E6E6E6;
+        --color-border-lilac : #d9d5e7;
+
+        /* font-size /
+        --text-xs : 0.75rem; / 12 /
+        --text-s : 0.875rem; / 14 /
+        --text-default : 1rem; / 사용하지 않아도 default 크기 16 / 
+        --text-m : 1.25rem; / 20 /
+        --text-l : 1.5rem; / 24 /
+        --text-xl : 2rem; / 32 */
 
         /* box-shadow */
         --shadow-default : 0 1px 10px rgba(170,170,170,25);
@@ -106,18 +127,38 @@ const GlobalStyles = () => (
       input {
         border: none;
       }
-
+      
+      input,textarea { font-size:  1rem}
+      
       .blind {
         position: absolute;
         width: 1px;
         height: 1px;
-        border: 0;
         margin: -1px;
-        padding:0;
-        clip: rect(0 0 0 0);
-        clip-path: inset(50%); 
         overflow: hidden;
       }
+
+      .react-datepicker-wrapper {
+        width: 100%;
+      }
+
+      ::-webkit-scrollbar {
+        width: 1vw; 
+      }
+      
+      ::-webkit-scrollbar-thumb {
+        background: linear-gradient(195deg, #8A96DB, #EFF1F8);  
+        border-radius: 30px;
+      }
+
+      ::-webkit-scrollbar-track {
+        background: transparent;
+      }
+
+      ::-webkit-scrollbar-corner {
+        background: transparent;
+      }
+
     `}
   />
 );


### PR DESCRIPTION
# Button style color props 추가 및 Link 태그 디자인 추가

![image](https://github.com/codestates-seb/seb44_main_016/assets/121333344/1b5bde89-65b9-40b6-b749-a64420c5620a)


<br/>

## 구현한 기능
1. 버튼 color props 추가, color props 지정 안할 시 default로 생성
2. 같은 디자인의 Link styled component 생성

<br/>

## 사용법

1. color props 없을 땐 default로 primary color이 적용됩니다.
2. color props에는 global style에서 선언한 변수 컬러를 문자열로 입력합니다.

```
  <S.SubmitBtn color='--color-point-blue' small>
      버튼
    </S.SubmitBtn>
    <S.SubmitBtn color='--color-point-red'>버튼</S.SubmitBtn>
    <S.SubmitBtn color='--color-point-yellow'>버튼</S.SubmitBtn>
    <S.SubmitBtn color='--color-point-lilac'>버튼</S.SubmitBtn>
    <S.LinkBtn href='/' color='--color-point-red'>
      링크
    </S.LinkBtn>
    <S.LinkBtn href='/' small>
      링크
    </S.LinkBtn>

```
