### PR TITLE
[FE] [🔥Hotfix] buttonProps-165 : LinkBtn 컴포넌트 props type error 수정 

### DIFF
--- a/client/src/styles/CommonStyles.tsx
+++ b/client/src/styles/CommonStyles.tsx
@@ -1,14 +1,18 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
 
-interface Props {
+interface ButtonProps {
   small?: boolean;
   large?: boolean;
   color?: string;
 }
+interface LinkProps {
+  size?: string;
+  color?: string;
+}
 
 const CommonStyles = {
-  SubmitBtn: styled.button<Props>`
+  SubmitBtn: styled.button<ButtonProps>`
     position: relative;
     display: inline-block;
     color: ${(props) =>
@@ -60,8 +64,8 @@ const CommonStyles = {
     width: auto;
     padding: 0.68rem 1.125rem;
     &::before {
-        width: 8rem;
-        height: 8rem;
+        width: 10rem;
+        height: 10rem;
         top:-1.6rem;
         left:-1.6rem;
       }
@@ -96,7 +100,7 @@ const CommonStyles = {
     width: 10rem;
   `}
   `,
-  LinkBtn: styled(Link)<Props>`
+  LinkBtn: styled(Link)<LinkProps>`
     position: relative;
     display: inline-block;
     color: ${(props) =>
@@ -143,14 +147,14 @@ const CommonStyles = {
       top: 2.5rem;
       left: 2.5rem;
     }
-    ${({ small }) =>
-      small &&
+    ${({ size }) =>
+      size === 'small' &&
       `
     width: auto;
     padding: 0.68rem 1.125rem;
     &::before {
-        width: 8rem;
-        height: 8rem;
+        width: 10rem;
+        height: 10rem;
         top:-1.6rem;
         left:-1.6rem;
       }
@@ -160,8 +164,8 @@ const CommonStyles = {
     }
   `}
 
-    ${({ large }) =>
-      large &&
+    ${({ size }) =>
+      size === 'large' &&
       `
     width: 100%;
     max-width: 40rem;
@@ -178,9 +182,9 @@ const CommonStyles = {
       }
   `}
   
-  ${({ small, large }) =>
-      !small &&
-      !large &&
+  ${({ size }) =>
+      size !== 'small' &&
+      size !== 'large' &&
       `
     width: 10rem;
   `}


### PR DESCRIPTION
# ex) 로그인 C 구현 

![image](https://github.com/codestates-seb/seb44_main_016/assets/121333344/72ebce4a-5e3d-4c6c-99e4-91b2719dd40c)


<br/>

## 문제 공유
commonStyles에서 만든 LinkBtn 컴포넌트가 boolean 값을 받지 못해 small, large를 전달하면 오류가 발생하였습니다. button 태그에선 가능했던 방법이 a태그에선 왜 불가한 지 알아보았습니다.

button 태그는 'disabled'같은 boolean 속성을 원래부터 전달할 수 있게 설계 되어있어서 large, small 등을 props로 전달하는 것에 문제가 없었지만 a태그는 boolean으로 처리하는 속성을 처음부터 갖고 있는 것이 없기 때문에 발생한 문제였습니다. 

<br/>

## 문제 해결 방법
- 새로 추가한 a태그 한정으로 props를 문자열로 전달하려합니다.
- 기존 Button도 같은 방식으로 수정하지 않는 이유 : 이미 작성한 부분이 많으실테니 문제되는 부분만 분리하여 수정

<br/>

## 사용법 
```ts
// 기존 SubmitBtn 사용시 small, large만 입력해도 boolean으로 props 전달
<S.SubmitBtn large>망고 간식주기</S.SubmitBtn> 

// a링크 사용시 size props에 string으로 props 전달
<S.LinkBtn href='/' size='large'>망고랑 놀아주기</S.LinkBtn> 
```
