### PR TITLE
[FE] Common 214 : 재활용 가능한 만능 셀렉트 박스 

### DIFF
--- a/client/src/components/SelectBox.tsx
+++ b/client/src/components/SelectBox.tsx
@@ -118,8 +118,7 @@ export default function SelectBox({
   const handleDropBoxClick = () => {
     setIsDropDownClicked((prev) => !prev);
     setIsLayoutClicked((prev) => !prev);
-    console.log(isDropDownClicked);
-    console.log(isLayoutClicked);
+
     if (!searchItem && isOnce) {
       setIsDropDownClicked((prev) => !prev);
       setIsLayoutClicked((prev) => !prev);

--- a/client/src/components/SelectBox.tsx
+++ b/client/src/components/SelectBox.tsx
@@ -83,15 +83,12 @@ export default function SelectBox({ id, placeholder, totalItem, searchItem, setS
       setSelectedOptionIndex(previousIndex);
       const selectedItem = previousFilteredItem[previousIndex];
       setSearchItem(selectedItem);
-    } else if (e.key === 'ArrowDown' && selectedOptionIndex < totalItem.length - 1) {
+    } else if (e.key === 'ArrowDown' && selectedOptionIndex < previousFilteredItem.length - 1) {
       e.preventDefault();
-      let nextIndex = selectedOptionIndex + 1;
+      const nextIndex = selectedOptionIndex + 1;
       setSelectedOptionIndex(nextIndex);
       const selectedItem = previousFilteredItem[nextIndex];
       setSearchItem(selectedItem);
-      if (nextIndex === previousFilteredItem.length - 1) {
-        nextIndex = previousFilteredItem.length - 1;
-      }
     } else if (e.key === 'Enter' && searchItem !== '') {
       e.preventDefault();
       setIsDropDownClicked(false);
@@ -102,7 +99,6 @@ export default function SelectBox({ id, placeholder, totalItem, searchItem, setS
     if (e.key === 'Backspace' && searchItem == '') {
       e.preventDefault();
       setIsOnceKeyboard(true);
-      console.log(isOnceKeyboard);
     } else if (e.key === 'Tab') {
       setIsOnceKeyboard(true);
     }

--- a/client/src/components/SelectBox.tsx
+++ b/client/src/components/SelectBox.tsx
@@ -9,8 +9,16 @@ interface SelectBoxProps {
   totalItem: string[];
   searchItem: string;
   setSearchItem: (value: string) => void;
+  ariaLabel?: string;
 }
-export default function SelectBox({ id, placeholder, totalItem, searchItem, setSearchItem }: SelectBoxProps) {
+export default function SelectBox({
+  id,
+  placeholder,
+  totalItem,
+  searchItem,
+  setSearchItem,
+  ariaLabel,
+}: SelectBoxProps) {
   const [previousFilteredItem, setPreviousFilteredItem] = useState<string[]>([]);
   const [isDropDownClicked, setIsDropDownClicked] = useState(false);
   const [isLayoutClicked, setIsLayoutClicked] = useState(false);
@@ -143,6 +151,7 @@ export default function SelectBox({ id, placeholder, totalItem, searchItem, setS
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
+            aria-label={ariaLabel}
           />
         ) : (
           <S.InputText
@@ -152,6 +161,7 @@ export default function SelectBox({ id, placeholder, totalItem, searchItem, setS
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
+            aria-label={ariaLabel}
           />
         )}
         <S.DropDownBtn

--- a/client/src/components/SelectBox.tsx
+++ b/client/src/components/SelectBox.tsx
@@ -101,6 +101,8 @@ export default function SelectBox({ id, placeholder, totalItem, searchItem, setS
       setIsOnceKeyboard(true);
     } else if (e.key === 'Tab') {
       setIsOnceKeyboard(true);
+      setIsDropDownClicked(false);
+      setIsLayoutClicked(false);
     }
   };
 

--- a/client/src/components/SelectBox.tsx
+++ b/client/src/components/SelectBox.tsx
@@ -118,7 +118,8 @@ export default function SelectBox({
   const handleDropBoxClick = () => {
     setIsDropDownClicked((prev) => !prev);
     setIsLayoutClicked((prev) => !prev);
-
+    console.log(isDropDownClicked);
+    console.log(isLayoutClicked);
     if (!searchItem && isOnce) {
       setIsDropDownClicked((prev) => !prev);
       setIsLayoutClicked((prev) => !prev);
@@ -127,6 +128,10 @@ export default function SelectBox({
     setSelectedOptionIndex(0);
     filteredItems = totalItem;
   };
+
+  useEffect(() => {
+    handleDropBoxClick();
+  }, []);
 
   const optionElements = filteredItems.map((el) => (
     <S.Li key={el} onClick={() => handleOptionClick(el)} className={searchItem === el ? 'selected' : ''}>

--- a/client/src/components/SelectBox.tsx
+++ b/client/src/components/SelectBox.tsx
@@ -102,6 +102,7 @@ export default function SelectBox({
       setIsDropDownClicked(false);
       setIsLayoutClicked(false);
       setIsOnceKeyboard(true);
+      setSelectedOptionIndex(-1);
     }
 
     if (e.key === 'Backspace' && searchItem == '') {

--- a/client/src/constants/selectItems.ts
+++ b/client/src/constants/selectItems.ts
@@ -11,4 +11,6 @@ export const EMAIL_DOMAIN = [
   'outlook.com',
   'hotmail.com',
   'yahoo.com',
+  'mango.com',
+  'mangolove.com'
 ];

--- a/client/src/constants/selectItems.ts
+++ b/client/src/constants/selectItems.ts
@@ -1,0 +1,14 @@
+export const EMAIL_DOMAIN = [
+  'naver.com',
+  'nate.com',
+  'kakao.com',
+  'gmail.com',
+  'daum.net',
+  'outlook.com',
+  'korea.kr',
+  'hanmail.com',
+  'outlook.kr',
+  'outlook.com',
+  'hotmail.com',
+  'yahoo.com',
+];

--- a/client/src/constants/selectItems.ts
+++ b/client/src/constants/selectItems.ts
@@ -12,5 +12,5 @@ export const EMAIL_DOMAIN = [
   'hotmail.com',
   'yahoo.com',
   'mango.com',
-  'mangolove.com'
+  'mangolove.com',
 ];

--- a/client/src/constants/selectItems.ts
+++ b/client/src/constants/selectItems.ts
@@ -7,8 +7,6 @@ export const EMAIL_DOMAIN = [
   'outlook.com',
   'korea.kr',
   'hanmail.com',
-  'outlook.kr',
-  'outlook.com',
   'hotmail.com',
   'yahoo.com',
   'mango.com',

--- a/client/src/pages/user/signup/SignUpForm.tsx
+++ b/client/src/pages/user/signup/SignUpForm.tsx
@@ -147,7 +147,7 @@ export default function SignUpForm() {
                     searchItem={domainValue}
                     setSearchItem={setDomainValue}
                     placeholder='직접 입력'
-                    aria-label='이메일 도메인 입력 또는 찾기'
+                    ariaLabel='이메일 도메인 입력 또는 찾기'
                   />
                 </S.DomainBox>
               )}

--- a/client/src/pages/user/signup/SignUpForm.tsx
+++ b/client/src/pages/user/signup/SignUpForm.tsx
@@ -9,6 +9,7 @@ import { SIGN_UP_MESSAGES } from '../../../constants/user';
 import SelectBox from '../../../components/SelectBox';
 import validation from '../../../utils/validationCheck';
 import apiUser from '../../../services/apiUser';
+import { EMAIL_DOMAIN } from '../../../constants/selectItems';
 import { useRefusalAni, isClickedStyled, SubmitBoxProps } from '../../../hooks/useRefusalAni';
 
 export default function SignUpForm() {
@@ -142,8 +143,10 @@ export default function SignUpForm() {
                 <S.DomainBox>
                   <div>@</div>
                   <SelectBox
+                    totalItem={EMAIL_DOMAIN}
                     searchItem={domainValue}
                     setSearchItem={setDomainValue}
+                    placeholder='직접 입력'
                     aria-label='이메일 도메인 입력 또는 찾기'
                   />
                 </S.DomainBox>


### PR DESCRIPTION
# 애정뿜뿜 자동 검색 셀렉트 박스 구현 

![셀렉트박스ㅠㅠ](https://github.com/codestates-seb/seb44_main_016/assets/125176463/13b01757-130f-4aac-b7f6-eeb85d408d59)

<br/>

## URL (이메일 도메인 부분)
https://zerohip-git-common-214-everland.vercel.app/user/signup

<br/>

## 구현한 기능

1. 키워드 입력하면 **자동 검색**이 됩니다.
2. 아무 것도 입력되지 않은 상태에서 드롭다운 활성화 아이콘을 클릭하면 선택할 수 있는 모든 항목들이 뜹니다.
3. 검색을 한 후, **키보드로 위 아래 이동을 하게 되면 인풋창의 값은 변하지만, 드롭다운의 기존 검색 내역은 변하지 않습니다.**
4. 원하는 인풋 값을 선택한 후 엔터를 누르면 해당 값이 선택되며 드롭다운이 꺼집니다.
5. 원하는 항목이 없는 경우 **직접 입력**도 가능합니다.

<br/>

## 비고
- 이 때까지 마음에 걸렸던 기능을 고칠 수 있어 너무 행복합니다 😭 
- 간단해 보이는 이 셀렉트 박스에 수많은 예외 상황과 로직들이 얽혀 있다는 것을 깨달았습니다. 
- 다양한 작동을 해보시고, 혹시 부자연스러운 작동 혹은 예외 상황이 추가적으로 있다면 바로 말씀 부탁드립니다..! 

<br/>

## 사용 방법
- 혹시 아래와 같은 방식(부모에서 자식으로 props 내려주는 것) 말고 다른 방식이 편하다고 생각되시면 말씀 부탁드립니다.
- 부모 컴포넌트에서 아래와 같이 props를 내려주시면 됩니다. id와 ariaLabel은 선택입니다. 
   - totalItem : 모든 항목
   - searchItem / setSearchItem : 부모 컴포넌트에서 onChange를 통해 변화한 state
   - placeholder

```javascript
import { EMAIL_DOMAIN } from '../../../constants/selectItems';
const [domainValue, setDomainValue] = useState('');   // 이메일 도메인 인풋 값 state


                  <SelectBox
                    totalItem={EMAIL_DOMAIN}
                    searchItem={domainValue}
                    setSearchItem={setDomainValue}
                    placeholder='직접 입력'
                    ariaLabel='이메일 도메인 입력 또는 찾기'
                  />
```

<br/>
