### PR TITLE
[FE] Commonization-188: 컴포넌트/함수 독립

### DIFF
--- a/client/src/components/ImgsCarousel.tsx
+++ b/client/src/components/ImgsCarousel.tsx
@@ -1,0 +1,101 @@
+import React from 'react'; // useState 사용
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+import CommonStyles from '../styles/CommonStyles';
+import useRangeNumber from '../hooks/useRangeNumber';
+import svgs from '../constants/svg';
+
+type Props = {
+  imgSrcs: string[];
+  width: string;
+  height: string;
+  rank?: number;
+};
+
+export default function ImgsCarousel(props: Props) {
+  const [isStart, isEnd, currentNum, setCurrentNum] = useRangeNumber(0, props.imgSrcs.length - 1); // 이미지 인덱스에 사용
+
+  return (
+    <S.ImgContainer style={{ height: props.height }}>
+      {props.rank && (
+        <S.RankIndicator>
+          <S.RankText>{`${props.rank}위`}</S.RankText>
+        </S.RankIndicator>
+      )}
+      <S.ImgsCarousel
+        style={{
+          transform: `translateX(calc(${props.width} * ${currentNum * -1}))`,
+        }}
+      >
+        {props.imgSrcs.map((imgSrc, i) => {
+          return (
+            <S.ImgBox key={i} style={{ width: props.width }}>
+              <S.Img src={imgSrc} alt={`사용자가 올린 ${i + 1}번째 사진`} />
+            </S.ImgBox>
+          );
+        })}
+      </S.ImgsCarousel>
+      {!isStart && (
+        <S.ImgSlideBtn position={'left'} onClick={() => setCurrentNum(currentNum - 1)}>
+          {svgs.slideLeft}
+        </S.ImgSlideBtn>
+      )}
+      {!isEnd && (
+        <S.ImgSlideBtn position={'right'} onClick={() => setCurrentNum(currentNum + 1)}>
+          {svgs.slideRight}
+        </S.ImgSlideBtn>
+      )}
+    </S.ImgContainer>
+  );
+}
+
+const S = {
+  ...CommonStyles,
+  ImgContainer: styled.div`
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    background-color: #ec4899;
+  `,
+  ImgsCarousel: styled.ol`
+    width: fit-content;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    transition: all 0.5s;
+  `,
+  ImgBox: styled.li`
+    height: 100%;
+  `,
+  Img: styled.img`
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  `,
+  ImgSlideBtn: styled.button<{ position: 'left' | 'right' }>`
+    position: absolute;
+    top: 50%;
+    left: ${(props) => (props.position === 'left' ? '5%' : '95%')};
+    transform: translate(-50%, -50%);
+    z-index: 997;
+  `,
+
+  RankIndicator: styled.div`
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(180deg, transparent 50%, rgba(0, 0, 0, 0.5) 100%);
+    display: flex;
+    justify-content: end;
+    align-items: end;
+    padding-right: 3rem;
+    padding-bottom: 2rem;
+    z-index: 996;
+  `,
+  RankText: styled.h2`
+    font-size: 3rem;
+    color: white;
+    border-bottom: 0.3rem solid white;
+  `,
+};

--- a/client/src/components/ImgsCarousel.tsx
+++ b/client/src/components/ImgsCarousel.tsx
@@ -7,14 +7,14 @@ import useRangeNumber from '../hooks/useRangeNumber';
 import svgs from '../constants/svg';
 
 type Props = {
-  imgSrcs: string[];
+  imgId: string[];
   width: string;
   height: string;
   rank?: number;
 };
 
 export default function ImgsCarousel(props: Props) {
-  const [isStart, isEnd, currentNum, setCurrentNum] = useRangeNumber(0, props.imgSrcs.length - 1); // 이미지 인덱스에 사용
+  const [isStart, isEnd, currentNum, setCurrentNum] = useRangeNumber(0, props.imgId.length - 1); // 이미지 인덱스에 사용
 
   return (
     <S.ImgContainer style={{ height: props.height }}>
@@ -28,7 +28,7 @@ export default function ImgsCarousel(props: Props) {
           transform: `translateX(calc(${props.width} * ${currentNum * -1}))`,
         }}
       >
-        {props.imgSrcs.map((imgSrc, i) => {
+        {props.imgId.map((imgSrc, i) => {
           return (
             <S.ImgBox key={i} style={{ width: props.width }}>
               <S.Img src={imgSrc} alt={`사용자가 올린 ${i + 1}번째 사진`} />

--- a/client/src/components/ImgsCarousel.tsx
+++ b/client/src/components/ImgsCarousel.tsx
@@ -1,6 +1,5 @@
 import React from 'react'; // useState 사용
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 
 import CommonStyles from '../styles/CommonStyles';
 import useRangeNumber from '../hooks/useRangeNumber';

--- a/client/src/components/SnsArticle.tsx
+++ b/client/src/components/SnsArticle.tsx
@@ -21,7 +21,7 @@ type PropsFeed = {
     userId: number;
     voteId: number;
     feedArticleHashtagId: number;
-    imgSrcs: string[];
+    imgId: string[];
   };
 };
 type PropsTimeline = {
@@ -38,7 +38,7 @@ type PropsTimeline = {
     userId: number;
     voteId: number;
     financialRecordArticleHashTagId: number;
-    imgSrcs: string[];
+    imgId: string[];
   };
 };
 
@@ -95,8 +95,8 @@ export default function SnsArticle({ type, data }: PropsFeed | PropsTimeline) {
             Waypil
           </ArticleHeader>
         )}
-        {data.imgSrcs.length >= 1 ? (
-          <ImgsCarousel imgSrcs={data.imgSrcs} width={'var(--article-w)'} height={'30rem'} />
+        {data.imgId.length >= 1 ? (
+          <ImgsCarousel imgId={data.imgId} width={'var(--article-w)'} height={'30rem'} />
         ) : (
           <></>
         )}

--- a/client/src/components/SnsArticle.tsx
+++ b/client/src/components/SnsArticle.tsx
@@ -4,12 +4,9 @@ import styled from '@emotion/styled';
 import CommonStyles from '../styles/CommonStyles';
 
 import ArticleHeader from './sns-article/ArticleHeader';
+import ImgsCarousel from '../components/ImgsCarousel';
 import VoteForm from './sns-article/VoteForm';
 import Comments from './sns-article/Comments';
-
-import useRangeNumber from '../hooks/useRangeNumber';
-
-import svgs from '../constants/svg';
 
 /* type은 추후 다른 파일로 분리하고 Import할 예정 */
 type PropsFeed = {
@@ -46,8 +43,6 @@ type PropsTimeline = {
 };
 
 export default function SnsArticle({ type, data }: PropsFeed | PropsTimeline) {
-  const [isStart, isEnd, currentNum, setCurrentNum] = useRangeNumber(0, data.imgSrcs.length - 1); // 이미지 인덱스에 사용
-
   let date, labelText, Label;
   if (type === 'feed') {
     date = data.createdAt;
@@ -101,37 +96,14 @@ export default function SnsArticle({ type, data }: PropsFeed | PropsTimeline) {
           </ArticleHeader>
         )}
         {data.imgSrcs.length >= 1 ? (
-          <S.ImgContainer>
-            <S.RankIndicator>
-              <S.RankText>1위</S.RankText>
-            </S.RankIndicator>
-            <S.ImgsCarousel currentImgIndex={currentNum}>
-              {data.imgSrcs.map((imgSrc, i) => {
-                return (
-                  <S.ImgBox>
-                    <S.Img src={imgSrc} alt={`사용자가 올린 ${i}번째 사진`} />
-                  </S.ImgBox>
-                );
-              })}
-            </S.ImgsCarousel>
-            {!isStart && (
-              <S.ImgSlideBtn position={'left'} onClick={() => setCurrentNum(currentNum - 1)}>
-                {svgs.slideLeft}
-              </S.ImgSlideBtn>
-            )}
-            {!isEnd && (
-              <S.ImgSlideBtn position={'right'} onClick={() => setCurrentNum(currentNum + 1)}>
-                {svgs.slideRight}
-              </S.ImgSlideBtn>
-            )}
-          </S.ImgContainer>
+          <ImgsCarousel imgSrcs={data.imgSrcs} width={'var(--article-w)'} height={'30rem'} />
         ) : (
           <></>
         )}
         <S.ArtileMain>
           {type !== 'feed' && data.title !== '' ? <S.TitleText>{data.title}</S.TitleText> : <></>}
           <S.ContextText>{data.content}</S.ContextText>
-          {type === 'feed' || <VoteForm savingRate={256} flexRate={48} />}
+          {type !== 'feed' || <VoteForm savingRate={256} flexRate={48} />}
           <S.UDForm>
             {/* CRUD의 U, D */}
             <S.UDBtn>수정</S.UDBtn>
@@ -173,53 +145,6 @@ const S = {
     border-top-left-radius: 10px;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
-  `,
-  ImgContainer: styled.div`
-    position: relative;
-    width: 100%;
-    height: 30rem;
-    overflow: hidden;
-    background-color: #ec4899;
-  `,
-  ImgsCarousel: styled.ol<{ currentImgIndex: number }>`
-    width: fit-content;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    transform: translateX(calc(var(--article-w) * ${(props) => props.currentImgIndex * -1}));
-    transition: all 0.5s;
-  `,
-  ImgBox: styled.li`
-    width: var(--article-w);
-  `,
-  Img: styled.img`
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  `,
-  ImgSlideBtn: styled.button<{ position: 'left' | 'right' }>`
-    position: absolute;
-    top: 50%;
-    left: ${(props) => (props.position === 'left' ? '5%' : '95%')};
-    transform: translate(-50%, -50%);
-    z-index: 997;
-  `,
-  RankIndicator: styled.div`
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(180deg, transparent 50%, rgba(0, 0, 0, 0.5) 100%);
-    display: flex;
-    justify-content: end;
-    align-items: end;
-    padding-right: 3rem;
-    padding-bottom: 2rem;
-    z-index: 996;
-  `,
-  RankText: styled.h2`
-    font-size: 3rem;
-    color: white;
-    border-bottom: 0.3rem solid white;
   `,
   ArtileMain: styled.div`
     width: 100%;

--- a/client/src/components/sns-article/ArticleHeader.tsx
+++ b/client/src/components/sns-article/ArticleHeader.tsx
@@ -1,21 +1,6 @@
 import styled from '@emotion/styled';
-
-/* Util 함수는 추후 다른 파일로 분리하고 Import할 예정 */
-function getKoreanDate(date: Date) {
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const hours = date.getHours().toString().padStart(2, '0'); // 한 자릿수라면 앞에 0 추가
-  const minutes = date.getMinutes().toString().padStart(2, '0'); // 한 자릿수라면 앞에 0 추가
-
-  const formattedDate = `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
-  return formattedDate;
-}
-function formatNumber(number: number): string {
-  const formattedNumber = Math.abs(number).toLocaleString();
-  const sign = number >= 0 ? '+' : '-';
-  return `${sign}${formattedNumber}`;
-}
+import { numToStrWithSign } from '../../utils/numToStrWithSign';
+import { convertToKoreanDate } from '../../utils/convertToKoreanDate';
 
 /* type은 추후 다른 파일로 분리하고 Import할 예정 */
 type PropsFeed = {
@@ -55,15 +40,15 @@ export default function ArticleHeaderComponent(props: PropsFeed | PropsTimeline)
           <S.ProfileImg />
         </S.ProfileImgButton>
         <S.Nickname>{props.children}</S.Nickname>
-        {props.type === 'feed' || <S.DateText>{getKoreanDate(props.createdAt)}</S.DateText>}
+        {props.type === 'feed' || <S.DateText>{convertToKoreanDate(props.createdAt)}</S.DateText>}
       </S.LeftDiv>
       <S.RightDiv>
         {props.type === 'feed' ? (
-          <S.DateText>{getKoreanDate(props.createdAt)}</S.DateText>
+          <S.DateText>{convertToKoreanDate(props.createdAt)}</S.DateText>
         ) : (
           <>
             {props.category === '' ? <></> : <S.CategoryText>{props.category}</S.CategoryText>}
-            <PriceText>{formatNumber(props.price)}</PriceText>
+            <PriceText>{numToStrWithSign(props.price)}</PriceText>
           </>
         )}
       </S.RightDiv>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -27,8 +27,7 @@ const TimelineArticleDummyA = {
   userId: 0,
   voteId: 0,
   financialRecordArticleHashTagId: 0,
-  imgSrcs: [
-    // 실제 API상에선 없음. Only 더미 데이터용. 실제 서버와 통신 시 관련 props 반드시 수정할 것.
+  imgId: [
     'https://images.unsplash.com/photo-1688574398156-92556aa3cf52?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1364&q=80',
     'https://images.unsplash.com/photo-1682685797366-715d29e33f9d?ixlib=rb-4.0.3&ixid=M3wxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1170&q=80',
     'https://images.unsplash.com/photo-1682686581030-7fa4ea2b96c3?ixlib=rb-4.0.3&ixid=M3wxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1170&q=80',
@@ -48,7 +47,7 @@ const TimelineArticleDummyB = {
   userId: 0,
   voteId: 0,
   financialRecordArticleHashTagId: 0,
-  imgSrcs: [], // 실제 API상에선 없음. Only 더미 데이터용. 실제 서버와 통신 시 관련 props 반드시 수정할 것.
+  imgId: [],
 };
 
 const feedArticleDummyA = {
@@ -62,8 +61,7 @@ const feedArticleDummyA = {
   userId: 0,
   voteId: 0,
   feedArticleHashtagId: 0,
-  imgSrcs: [
-    // 실제 API상에선 없음. Only 더미 데이터용. 실제 서버와 통신 시 관련 props 반드시 수정할 것.
+  imgId: [
     'https://images.unsplash.com/photo-1682686581030-7fa4ea2b96c3?ixlib=rb-4.0.3&ixid=M3wxMjA3fDF8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1170&q=80',
     'https://images.unsplash.com/photo-1688574398156-92556aa3cf52?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1364&q=80',
   ],
@@ -80,8 +78,7 @@ const feedArticleDummyB = {
   userId: 0,
   voteId: 0,
   feedArticleHashtagId: 0,
-  imgSrcs: [
-    // 실제 API상에선 없음. Only 더미 데이터용. 실제 서버와 통신 시 관련 props 반드시 수정할 것.
+  imgId: [
     'https://images.unsplash.com/photo-1688840170202-6e8fe4cf8ec9?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1287&q=80',
   ],
 };

--- a/client/src/services/apiUser.ts
+++ b/client/src/services/apiUser.ts
@@ -2,8 +2,7 @@ import axios, { AxiosResponse } from 'axios';
 import { PostSignUp, LoginReqData } from '../types/user';
 import { tokenInstance } from './loginInstance';
 
-// const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
-const BASE_URL = 'https://zerohip-git-user-175-everland.vercel.app/api';
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 const apiUser = {
   /** 회원 가입 */

--- a/client/src/utils/convertToKoreanDate.ts
+++ b/client/src/utils/convertToKoreanDate.ts
@@ -1,0 +1,11 @@
+/** 12345를 집어넣으면 "+12,345" 반환, -98765를 집어넣으면 "-98,765" 반환 */
+export function convertToKoreanDate(date: Date) {
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = date.getHours().toString().padStart(2, '0'); // 한 자릿수라면 앞에 0 추가
+  const minutes = date.getMinutes().toString().padStart(2, '0'); // 한 자릿수라면 앞에 0 추가
+
+  const formattedDate = `${year}년 ${month}월 ${day}일 ${hours}:${minutes}`;
+  return formattedDate;
+}

--- a/client/src/utils/numToStrWithSign.ts
+++ b/client/src/utils/numToStrWithSign.ts
@@ -1,0 +1,6 @@
+/** 12345를 집어넣으면 "+12,345" 반환, -98765를 집어넣으면 "-98,765" 반환 */
+export function numToStrWithSign(number: number): string {
+  const formattedNumber = Math.abs(number).toLocaleString();
+  const sign = number >= 0 ? '+' : '-';
+  return `${sign}${formattedNumber}`;
+}


### PR DESCRIPTION
# [FE] Commonization-188: 컴포넌트/함수 독립

## 구현한 기능 & 변경 내역
* chore: `<ImgsCarousel>` 컴포넌트 독립
* chore: `convertToKoreanDate()`, `numToStrWithSign()` 함수 독립
  * rename: `getKoreanDate` → `convertToKoreanDate`
  * rename: `formatNumber` → `numToStrWithSign`
* fix: `<VoteForm>` 보이는 조건문이 정반대로 되어 있는 버그 수정
* rename: imgSrcs → imgId

<br/>

## ImgsCarousel 사용법
```tsx
import ImgsCarousel from '../components/ImgsCarousel';

<ImgsCarousel imgId={imgId} width={'var(--article-w)'} height={'30rem'} rank={1} />
```
* `imgId<string[]>`: 이미지 링크가 담긴 배열을 이곳에 할당
* `width<string>`: CSS 값을 이곳에 할당
* `height<string>`: CSS 값을 이곳에 할당
* `rank<number>`: 없어도 됨. 명예의 전당에서만 사용할 예정. 예를 들어 1을 할당하면 '1위'라고 표시된다.
