### PR TITLE
[FE] carousel-swiper: Swiper.js 라이브러리로 이미지 캐러셀 개선

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,7 +22,8 @@
         "react-easy-crop": "^5.0.0",
         "react-lottie-player": "^1.5.4",
         "react-redux": "^8.1.1",
-        "react-toastify": "^9.1.3"
+        "react-toastify": "^9.1.3",
+        "swiper": "^10.0.4"
       },
       "devDependencies": {
         "@babel/core": "^7.21.4",
@@ -7270,6 +7271,24 @@
       "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-10.0.4.tgz",
+      "integrity": "sha512-DlNR3KiaVkPep6RraZ2tNr7lvyuzELuR+4NZr4wO42t0UworIO3DxDlz8b5Q3uUioh7cJad99EdRJLkPF+r8Ag==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,8 @@
     "react-easy-crop": "^5.0.0",
     "react-lottie-player": "^1.5.4",
     "react-redux": "^8.1.1",
-    "react-toastify": "^9.1.3"
+    "react-toastify": "^9.1.3",
+    "swiper": "^10.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/client/src/components/ImgsCarousel.tsx
+++ b/client/src/components/ImgsCarousel.tsx
@@ -1,9 +1,12 @@
 import React from 'react'; // useState 사용
 import styled from '@emotion/styled';
 
+import { Navigation, Pagination, Scrollbar, A11y } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react'; // Import Swiper React components
+import 'swiper/css'; // Import Swiper styles
+import 'swiper/css/navigation';
+
 import CommonStyles from '../styles/CommonStyles';
-import useRangeNumber from '../hooks/useRangeNumber';
-import svgs from '../constants/svg';
 
 type Props = {
   imgId: string[];
@@ -13,8 +16,6 @@ type Props = {
 };
 
 export default function ImgsCarousel(props: Props) {
-  const [isStart, isEnd, currentNum, setCurrentNum] = useRangeNumber(0, props.imgId.length - 1); // 이미지 인덱스에 사용
-
   return (
     <S.ImgContainer style={{ height: props.height }}>
       {props.rank && (
@@ -22,29 +23,30 @@ export default function ImgsCarousel(props: Props) {
           <S.RankText>{`${props.rank}위`}</S.RankText>
         </S.RankIndicator>
       )}
-      <S.ImgsCarousel
-        style={{
-          transform: `translateX(calc(${props.width} * ${currentNum * -1}))`,
+      <Swiper
+        // install Swiper modules
+        modules={[Navigation, Pagination, Scrollbar, A11y]}
+        spaceBetween={0}
+        slidesPerView={1}
+        navigation={{
+          nextEl: '.swiper-button-next',
+          prevEl: '.swiper-button-prev',
         }}
+        pagination={{ clickable: true }}
+        scrollbar={{ draggable: true }}
+        // onSwiper={(swiper) => console.log(swiper)}
+        // onSlideChange={() => console.log('slide change')}
       >
+        <S.ImgSlideBtn className='swiper-button-next' type='button' />
+        <S.ImgSlideBtn className='swiper-button-prev' type='button' />
         {props.imgId.map((imgSrc, i) => {
           return (
-            <S.ImgBox key={i} style={{ width: props.width }}>
+            <SwiperSlide key={i}>
               <S.Img src={imgSrc} alt={`사용자가 올린 ${i + 1}번째 사진`} />
-            </S.ImgBox>
+            </SwiperSlide>
           );
         })}
-      </S.ImgsCarousel>
-      {!isStart && (
-        <S.ImgSlideBtn position={'left'} onClick={() => setCurrentNum(currentNum - 1)}>
-          {svgs.slideLeft}
-        </S.ImgSlideBtn>
-      )}
-      {!isEnd && (
-        <S.ImgSlideBtn position={'right'} onClick={() => setCurrentNum(currentNum + 1)}>
-          {svgs.slideRight}
-        </S.ImgSlideBtn>
-      )}
+      </Swiper>
     </S.ImgContainer>
   );
 }
@@ -55,29 +57,34 @@ const S = {
     position: relative;
     width: 100%;
     overflow: hidden;
-    background-color: #ec4899;
-  `,
-  ImgsCarousel: styled.ol`
-    width: fit-content;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    transition: all 0.5s;
-  `,
-  ImgBox: styled.li`
-    height: 100%;
+    background-color: #f0f3f8;
+    & .swiper-initialized {
+      height: 100%;
+    }
+    & .swiper-slide {
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+    & .swiper-slide {
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
   `,
   Img: styled.img`
     width: 100%;
     height: 100%;
     object-fit: cover;
   `,
-  ImgSlideBtn: styled.button<{ position: 'left' | 'right' }>`
-    position: absolute;
-    top: 50%;
-    left: ${(props) => (props.position === 'left' ? '5%' : '95%')};
-    transform: translate(-50%, -50%);
-    z-index: 997;
+  ImgSlideBtn: styled.button`
+    color: white;
+    filter: drop-shadow(0px 1px 2px black); // 그림자
+    &.swiper-button-disabled {
+      visibility: hidden;
+    }
   `,
 
   RankIndicator: styled.div`

--- a/client/src/components/ImgsCarousel.tsx
+++ b/client/src/components/ImgsCarousel.tsx
@@ -11,13 +11,13 @@ import CommonStyles from '../styles/CommonStyles';
 type Props = {
   imgId: string[];
   width: string;
-  height: string;
+  // height: string;
   rank?: number;
 };
 
 export default function ImgsCarousel(props: Props) {
   return (
-    <S.ImgContainer style={{ height: props.height }}>
+    <S.ImgContainer>
       {props.rank && (
         <S.RankIndicator>
           <S.RankText>{`${props.rank}위`}</S.RankText>
@@ -56,8 +56,9 @@ const S = {
   ImgContainer: styled.div`
     position: relative;
     width: 100%;
+    height: var(--imgcarousel-h);
     overflow: hidden;
-    background-color: #f0f3f8;
+    background-color: #f8f9fc;
     & .swiper-initialized {
       height: 100%;
     }

--- a/client/src/components/SnsArticle.tsx
+++ b/client/src/components/SnsArticle.tsx
@@ -95,11 +95,7 @@ export default function SnsArticle({ type, data }: PropsFeed | PropsTimeline) {
             Waypil
           </ArticleHeader>
         )}
-        {data.imgId.length >= 1 ? (
-          <ImgsCarousel imgId={data.imgId} width={'var(--article-w)'} height={'30rem'} />
-        ) : (
-          <></>
-        )}
+        {data.imgId.length >= 1 ? <ImgsCarousel imgId={data.imgId} width={'var(--article-w)'} /> : <></>}
         <S.ArtileMain>
           {type !== 'feed' && data.title !== '' ? <S.TitleText>{data.title}</S.TitleText> : <></>}
           <S.ContextText>{data.content}</S.ContextText>

--- a/client/src/styles/GlobalStyles.tsx
+++ b/client/src/styles/GlobalStyles.tsx
@@ -82,6 +82,7 @@ const GlobalStyles = () => (
         --header-h : 5rem;
         --main-w : calc(var(--app-max-w) - var(--aside-w));
         --article-w : 45rem;
+        --imgcarousel-h : 23rem;
       }
 
       li {


### PR DESCRIPTION
# [FE] carousel-swiper: Swiper.js 라이브러리로 이미지 캐러셀 개선
![image](https://github.com/codestates-seb/seb44_main_016/assets/65957855/a9b3ada6-0d7e-4b3d-9e1d-7776071053b8)

## 구현한 기능 & 변경 내역
1. install: `swiper` 라이브러리 설치 (https://swiperjs.com/)
2. fix: width에 퍼센트(%) 값이 들어와도 정상적으로 작동 (`<FaRecArticle>`에 바로 적용 가능!)
3. chore: 이미지 캐러셀의 height를 `23rem`으로 고정 & 통일
4. design: 이미지 캐러셀의 background-color를 `#f8f9fc`로 설정

<br/>

## 비고
`react-slick`에 이틀 매달려서 안 된 게 `swiper`로 바꾸고 나서 2시간 만에 성공했네요 ㅠㅠ