### PR TITLE
[BE] Article Interface to Abstract Class

### DIFF
--- a/server/src/main/java/com/zerohip/server/common/article/Article.java
+++ b/server/src/main/java/com/zerohip/server/common/article/Article.java
@@ -1,7 +1,41 @@
 package com.zerohip.server.common.article;
 
-public interface Article {
 
-  Long id = null;
-  String content = null;
+import com.zerohip.server.common.audit.Auditable;
+import com.zerohip.server.common.scope.Scope;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@MappedSuperclass
+public abstract class Article extends Auditable {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  private String content;
+
+  /**
+   * 글의 공개 범위
+   * - 가계부 게시글(FAREC_ARTICLE)
+   * - 가계부 게시글(FAREC_TIMELINE)
+   * - 피드(FEED)
+   */
+  @NotNull
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private Scope scope;
+
+  public Article(Scope scope) {
+    super();
+  }
 }

--- a/server/src/main/java/com/zerohip/server/common/comment/dto/CommentDto.java
+++ b/server/src/main/java/com/zerohip/server/common/comment/dto/CommentDto.java
@@ -1,0 +1,37 @@
+package com.zerohip.server.common.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+public class CommentDto {
+
+  @Getter
+  @AllArgsConstructor
+  public static class Post {
+    @Size(max = 2_000)
+    @NotBlank
+    private String content;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class Patch {
+    @Size(max = 2_000)
+    @NotBlank
+    private String content;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  public static class Response {
+    private Long commentId;
+    private String content;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+  }
+}

--- a/server/src/main/java/com/zerohip/server/common/comment/dto/CommentDto.java
+++ b/server/src/main/java/com/zerohip/server/common/comment/dto/CommentDto.java
@@ -1,9 +1,11 @@
 package com.zerohip.server.common.comment.dto;
 
+import com.zerohip.server.user.dto.UserDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
@@ -15,6 +17,10 @@ public class CommentDto {
     @Size(max = 2_000)
     @NotBlank
     private String content;
+    @NotNull
+    private UserDto.Response user;
+    @NotNull
+    private Long ArticleId;
   }
 
   @Getter
@@ -33,5 +39,8 @@ public class CommentDto {
 
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
+    private UserDto.Response user;
+    private Long ArticleId;
   }
 }

--- a/server/src/main/java/com/zerohip/server/common/comment/entity/Comment.java
+++ b/server/src/main/java/com/zerohip/server/common/comment/entity/Comment.java
@@ -1,14 +1,14 @@
 package com.zerohip.server.common.comment.entity;
 
 import com.zerohip.server.common.audit.Auditable;
+import com.zerohip.server.feedArticle.entity.FeedArticle;
+import com.zerohip.server.financialRecordArticle.entity.FinancialRecordArticle;
+import com.zerohip.server.user.entity.User;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
@@ -28,10 +28,18 @@ public class Comment extends Auditable {
   @Column(nullable = false, unique = false, updatable = true, length = 2_000)
   private String content;
 
+  @ManyToOne
+  @JoinColumn(name = "fianancial-record-article-id")
+  private FinancialRecordArticle financialRecordArticle;
+
+  @ManyToOne
+  @JoinColumn(name = "feed-article-id")
+  private FeedArticle feedArticle;
+
+  @ManyToOne
+  @JoinColumn(name = "user-id")
+  private User user;
   /**
-   * - 피드 게시물
-   * - 가계부 게시물
    * - 좋아요
-   * - 유저
    */
 }

--- a/server/src/main/java/com/zerohip/server/common/comment/entity/Comment.java
+++ b/server/src/main/java/com/zerohip/server/common/comment/entity/Comment.java
@@ -1,0 +1,37 @@
+package com.zerohip.server.common.comment.entity;
+
+import com.zerohip.server.common.audit.Auditable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+import static javax.persistence.GenerationType.IDENTITY;
+
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+public class Comment extends Auditable {
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long commentId;
+
+  @Size(max = 2_000)
+  @NotBlank
+  @Column(nullable = false, unique = false, updatable = true, length = 2_000)
+  private String content;
+
+  /**
+   * - 피드 게시물
+   * - 가계부 게시물
+   * - 좋아요
+   * - 유저
+   */
+}

--- a/server/src/main/java/com/zerohip/server/common/comment/repository/CommentRepository.java
+++ b/server/src/main/java/com/zerohip/server/common/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.zerohip.server.common.comment.repository;
+
+import com.zerohip.server.common.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/server/src/main/java/com/zerohip/server/common/comment/service/CommentService.java
+++ b/server/src/main/java/com/zerohip/server/common/comment/service/CommentService.java
@@ -1,0 +1,19 @@
+package com.zerohip.server.common.comment.service;
+
+import com.zerohip.server.common.comment.dto.CommentDto;
+import com.zerohip.server.common.comment.entity.Comment;
+import org.springframework.data.domain.Page;
+
+public interface CommentService {
+  Comment createComment(Comment comment);
+
+  Comment findComment(Long commentId);
+
+  Page<Comment> findComments(int page, int size);
+
+  Comment updateComment(Long commentId, CommentDto.Patch patchParam);
+
+  void deleteComment(Long commentId);
+
+  Comment findVerifiedComment(Long commentId);
+}

--- a/server/src/main/java/com/zerohip/server/common/comment/service/CommentServiceImpl.java
+++ b/server/src/main/java/com/zerohip/server/common/comment/service/CommentServiceImpl.java
@@ -1,0 +1,58 @@
+package com.zerohip.server.common.comment.service;
+
+import com.zerohip.server.common.comment.dto.CommentDto;
+import com.zerohip.server.common.comment.entity.Comment;
+import com.zerohip.server.common.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentServiceImpl implements CommentService {
+
+  private final CommentRepository repository;
+
+  @Override
+  public Comment createComment(Comment postParam) {
+    return repository.save(postParam);
+  }
+
+  @Override
+  public Comment findComment(Long commentId) {
+    return findVerifiedComment(commentId);
+  }
+
+  @Override
+  public Page<Comment> findComments(int page, int size) {
+    return repository.findAll(PageRequest.of(page -1, size, Sort.by("commentId").descending()));
+  }
+
+  @Override
+  public Comment updateComment(Long commentId, CommentDto.Patch patchParam) {
+    Comment findComment = findVerifiedComment(commentId);
+    findComment.setContent(patchParam.getContent());
+
+    Comment updateComment = repository.save(findComment);
+    return updateComment;
+  }
+
+  @Override
+  public void deleteComment(Long commentId) {
+    Comment findComment = findVerifiedComment(commentId);
+    repository.delete(findComment);
+  }
+
+  @Override
+  public Comment findVerifiedComment(Long commentId) {
+    Optional<Comment> optionalComment = repository.findById(commentId);
+    Comment findComment = optionalComment.orElseThrow(() -> new RuntimeException("존재하지 않는 댓글입니다."));
+    return findComment;
+  }
+}

--- a/server/src/main/java/com/zerohip/server/feedArticle/entity/FeedArticle.java
+++ b/server/src/main/java/com/zerohip/server/feedArticle/entity/FeedArticle.java
@@ -1,13 +1,14 @@
 package com.zerohip.server.feedArticle.entity;
 
+import com.zerohip.server.common.article.Article;
 import com.zerohip.server.common.feedType.FeedType;
-import com.zerohip.server.common.audit.Auditable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import javax.validation.constraints.Size;
 
 @Entity
 @Table(name = "feedArticles")
@@ -15,18 +16,15 @@ import javax.persistence.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class FeedArticle extends Auditable {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long feedArticleId;
+public class FeedArticle extends Article {
 
     //feedType - 절약팁, 허락해줘 선택
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private FeedType feedType;
 
-    //@Size -> 본문 문자열 크기 정하고 나서 사용
-    @Column(nullable = false)
+    @Size(max = 2_000)
+    @Column(nullable = false, length = 2_000)
     private String content;
 
     //피드게시글 작성시간은 Auditable 상속받기 때문에 아예 필드변수 없어도 ok.

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
@@ -1,12 +1,10 @@
 package com.zerohip.server.financialRecordArticle.entity;
 
 import com.zerohip.server.common.article.Article;
-import com.zerohip.server.common.audit.Auditable;
 import com.zerohip.server.common.img.entity.Img;
-import com.zerohip.server.common.scope.Scope;
 import com.zerohip.server.financialRecord.entity.FinancialRecord;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
@@ -15,7 +13,6 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 
 /**
@@ -23,21 +20,17 @@ import java.util.List;
  * Date!? String!?
  * - String으로 저장하면, 조회할 때, String을 Date로 변환해야 한다.
  */
-@NoArgsConstructor
 @Setter
 @Getter
 @Entity
-public class FinancialRecordArticle extends Auditable implements Article {
-
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long financialRecordArticleId;
+@AllArgsConstructor
+public class FinancialRecordArticle extends Article {
 
   @Size(max = 30)
   @Column(nullable = true, unique = false, updatable = true, length = 30)
   private String title;
-  @Size(max = 10000)
-  @Column(nullable = true, unique = false, updatable = true, length = 10000)
+  @Size(max = 2_000)
+  @Column(nullable = true, unique = false, updatable = true, length = 2_000)
   private String content;
   @NotNull
   @Column(nullable = false, unique = false, updatable = true)
@@ -50,19 +43,9 @@ public class FinancialRecordArticle extends Auditable implements Article {
   @Column(nullable = false, unique = false, updatable = true)
   private Integer price;
 
-  /**
-   * 글의 공개 범위
-   * - 가계부 게시글(FAREC_ARTICLE)
-   * - 가계부 게시글(FAREC_TIMELINE)
-   * - 피드(FEED)
-   */
-  @NotNull
-  @Enumerated(EnumType.STRING)
-  private Scope scope;
-
   // 가계부 매핑
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "financialRecordId")
+  @JoinColumn(name = "financial-Record-id")
   private FinancialRecord financialRecord;
 
   // 이미지 매핑
@@ -71,15 +54,7 @@ public class FinancialRecordArticle extends Auditable implements Article {
   @OneToMany(mappedBy = "financialRecordArticle", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Img> imgList = new ArrayList<>();
 
-  public FinancialRecordArticle(String title, String content, LocalDate faDate, String category, int price, Scope scope, FinancialRecord financialRecord) {
-    this.title = title;
-    this.content = content;
-    this.faDate = faDate;
-    this.category = category;
-    this.price = price;
-    this.scope = scope;
-    this.financialRecord = financialRecord;
-  }
+  public FinancialRecordArticle() {super();}
   // 유저 매핑
 
   // 댓글 매핑


### PR DESCRIPTION

## 구현한 기능
1. Article 인터페이스 -> 추상클래스 변경
    - FeedArticle&FinancialRecordArticle 공동 필드 추가(id, content, scope)
    - ⭐️ 추상화로 인해 각 기능의 id를 xxxId -> id로 사용하는것에 대한 의견이 궁금합니다
    - content는 각 엔티티의 양식이 달라 따로 Valid설정❌.
    - 위의 이유로 content는 자식클래스에서 커스텀되기때문에 생성자에 포함❌.
    - Article에서 Auditable을 상속받아 각 엔티티의 확장구조 변경

<br/>

## 비고
