### PR TITLE
[BE] 가계부/가계부게시글 - 인가된 사용자 로직 수정 

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -5,6 +5,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+../client/
 
 ### STS ###
 .apt_generated

--- a/server/src/main/java/com/zerohip/server/common/page/dto/MultiResponseDto.java
+++ b/server/src/main/java/com/zerohip/server/common/page/dto/MultiResponseDto.java
@@ -15,4 +15,8 @@ public class MultiResponseDto<T> {
     this.pageInfo = new PageInfo(page.getNumber() + 1,
             page.getSize(), page.getTotalElements(), page.getTotalPages());
   }
+
+  public MultiResponseDto(List<T> data) {
+    this.data = data;
+  }
 }

--- a/server/src/main/java/com/zerohip/server/financialRecord/dto/FinancialRecordDto.java
+++ b/server/src/main/java/com/zerohip/server/financialRecord/dto/FinancialRecordDto.java
@@ -37,6 +37,7 @@ public class FinancialRecordDto {
     private String memo;
     private int totalCount;
     private int timeLineCount;
+    private boolean isBookmark;
 
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;

--- a/server/src/main/java/com/zerohip/server/financialRecord/entity/FinancialRecord.java
+++ b/server/src/main/java/com/zerohip/server/financialRecord/entity/FinancialRecord.java
@@ -42,6 +42,9 @@ public class FinancialRecord extends Auditable {
   @Column(nullable = false, unique = false, updatable = false, columnDefinition = "integer default 0")
   private int timeLineCount;
 
+  @Column(columnDefinition = "boolean default false")
+  private boolean isBookmark;
+
   // 게시물 수
   @OneToMany(mappedBy = "financialRecord", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<FinancialRecordArticle> financialRecordArticles; // 글 매핑(List 형식)
@@ -50,12 +53,6 @@ public class FinancialRecord extends Auditable {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
-
-  @PrePersist
-  public void prePersist() {
-    this.totalCount = 0;
-    this.timeLineCount = 0;
-  }
 
   public FinancialRecord(String financialRecordName, String memo) {
     this.financialRecordName = financialRecordName;

--- a/server/src/main/java/com/zerohip/server/financialRecord/entity/FinancialRecord.java
+++ b/server/src/main/java/com/zerohip/server/financialRecord/entity/FinancialRecord.java
@@ -9,14 +9,15 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.util.List;
 
-
+@Entity
+@Table(name = "financialRecords")
 @Setter
 @Getter
-@Entity
 @NoArgsConstructor
 @AllArgsConstructor
 public class FinancialRecord extends Auditable {
@@ -33,11 +34,11 @@ public class FinancialRecord extends Auditable {
   @Column(nullable = true, unique = false, updatable = true)
   private String memo;
 
-  @Size(min = 0)
+  @Min(0)
   @Column(nullable = false, unique = false, updatable = false, columnDefinition = "integer default 0")
   private int totalCount;
 
-  @Size(min = 0)
+  @Min(0)
   @Column(nullable = false, unique = false, updatable = false, columnDefinition = "integer default 0")
   private int timeLineCount;
 
@@ -47,7 +48,7 @@ public class FinancialRecord extends Auditable {
 
   // 유저 매핑(List 형식)
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user-id")
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @PrePersist

--- a/server/src/main/java/com/zerohip/server/financialRecord/service/FinancialRecordService.java
+++ b/server/src/main/java/com/zerohip/server/financialRecord/service/FinancialRecordService.java
@@ -25,4 +25,6 @@ public interface FinancialRecordService {
 
   // 가계부 조회확인
   FinancialRecord findVerifiedFaRec(Long faRecId);
+
+  public User findUser(User author);
 }

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/controller/FinancialRecordArticleController.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/controller/FinancialRecordArticleController.java
@@ -28,17 +28,17 @@ import java.util.List;
 @RequestMapping("/financial-record/{financial-record-id}/article")
 public class FinancialRecordArticleController {
 
-  private final static String FINANCIAL_RECORD_ARTICLE_DEFAULT_URI = "/financial-record/{financialRecordId}/article";
   private final FinancialRecordArticleService service;
   private final FinancialRecordArticleMapper mapper;
 
   @PostMapping
   public ResponseEntity createFinancialRecordArticle(@Valid @RequestBody FinancialRecordArticleDto.Post requestbody,
+                                                     @PathVariable("financial-record-id") Long financialRecordId,
                                                      @AuthenticationPrincipal User author) {
 
-    FinancialRecordArticle saveFaRecArticle = service.createFaRecArticle(author, mapper.financialRecordArticlePostToFinancialRecordArticle(requestbody));
+    FinancialRecordArticle saveFaRecArticle = service.createFaRecArticle(financialRecordId, author, mapper.financialRecordArticlePostToFinancialRecordArticle(requestbody));
 
-    URI uri = URI.create(FINANCIAL_RECORD_ARTICLE_DEFAULT_URI + "/" + saveFaRecArticle.getArticleId());
+    URI uri = URI.create("/financial-record/" + financialRecordId + "/article/" + saveFaRecArticle.getArticleId());
 
     log.info("saveFaRecArticle.getCreatedAt() : {}", saveFaRecArticle.getCreatedAt());
 

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
@@ -66,7 +66,7 @@ public class FinancialRecordArticleDto {
   @Getter
   @AllArgsConstructor
   public static class Response {
-    private Long financialRecordArticleId;
+    private Long articleId;
     private String title;
     private String content;
     private LocalDate faDate;

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/dto/FinancialRecordArticleDto.java
@@ -83,5 +83,10 @@ public class FinancialRecordArticleDto {
     // 댓글 매핑 데이터
     // 좋아요 매핑 데이터
     // 해시태그 매핑 데이터
+
+
+    public void setFinancialRecordId(Long financialRecordId) {
+      this.financialRecordId = financialRecordId;
+    }
   }
 }

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/entity/FinancialRecordArticle.java
@@ -49,7 +49,7 @@ public class FinancialRecordArticle extends Article {
 
   // 가계부 매핑
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "financial-Record-id")
+  @JoinColumn(name = "financial_Record_id")
   private FinancialRecord financialRecord;
 
   // 이미지 매핑
@@ -60,7 +60,7 @@ public class FinancialRecordArticle extends Article {
 
   // 유저 매핑
   @ManyToOne
-  @JoinColumn(name = "user-id")
+  @JoinColumn(name = "user_id")
   private User user;
   // 댓글 매핑
   // 좋아요 매핑

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/mapper/FinancialRecordArticleMapper.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/mapper/FinancialRecordArticleMapper.java
@@ -2,7 +2,9 @@ package com.zerohip.server.financialRecordArticle.mapper;
 
 import com.zerohip.server.financialRecordArticle.dto.FinancialRecordArticleDto;
 import com.zerohip.server.financialRecordArticle.entity.FinancialRecordArticle;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
 
 import javax.swing.*;
 
@@ -12,9 +14,15 @@ import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 import static org.mapstruct.ReportingPolicy.IGNORE;
 
 @Mapper(componentModel = SPRING, unmappedTargetPolicy = IGNORE)
-public interface FinancialRecordArticleMapper {
-  FinancialRecordArticle financialRecordArticlePostToFinancialRecordArticle(FinancialRecordArticleDto.Post requestbody);
-  FinancialRecordArticle financialRecordArticlePatchToFinancialRecordArticle(FinancialRecordArticleDto.Patch requestbody);
-  FinancialRecordArticleDto.Response financialRecordArticleToFinancialRecordArticleResponse(FinancialRecordArticle financialRecordArticle);
-  List<FinancialRecordArticleDto.Response> financialRecordArticlesToFinancialRecordArticleResponses(List<FinancialRecordArticle> financialRecordArticles);
+public abstract class FinancialRecordArticleMapper {
+
+  public abstract FinancialRecordArticle financialRecordArticlePostToFinancialRecordArticle(FinancialRecordArticleDto.Post requestbody);
+  public abstract FinancialRecordArticle financialRecordArticlePatchToFinancialRecordArticle(FinancialRecordArticleDto.Patch requestbody);
+  public abstract FinancialRecordArticleDto.Response financialRecordArticleToFinancialRecordArticleResponse(FinancialRecordArticle financialRecordArticle);
+  public abstract List<FinancialRecordArticleDto.Response> financialRecordArticlesToFinancialRecordArticleResponses(List<FinancialRecordArticle> financialRecordArticles);
+
+  @AfterMapping
+  protected void mapFinancialRecordId(FinancialRecordArticle financialRecordArticle, @MappingTarget FinancialRecordArticleDto.Response response) {
+    response.setFinancialRecordId(financialRecordArticle.getFinancialRecord().getFinancialRecordId());
+  }
 }

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleService.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleService.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface FinancialRecordArticleService {
   // 가계부 게시글 생성
-  FinancialRecordArticle createFaRecArticle(User author, FinancialRecordArticle faRecArticle);
+  FinancialRecordArticle createFaRecArticle(Long financialRecordId, User author, FinancialRecordArticle faRecArticle);
   // 가계부 게시글 조회(단건)
   FinancialRecordArticle findFaRecArticle(Long faRecArticleId);
   // 가계부 게시글 조회(전체)
@@ -20,4 +20,6 @@ public interface FinancialRecordArticleService {
   void deleteFaRecArticle(User author, Long faRecArticleId);
   // 가계부 게시글 조회 확인
   FinancialRecordArticle findVerifiedFaRecArticle(Long faRecArticleId);
+
+  User findUser(User author);
 }

--- a/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleServiceImpl.java
+++ b/server/src/main/java/com/zerohip/server/financialRecordArticle/service/FinancialRecordArticleServiceImpl.java
@@ -10,6 +10,7 @@ import com.zerohip.server.financialRecordArticle.dto.FinancialRecordArticleDto;
 import com.zerohip.server.financialRecordArticle.entity.FinancialRecordArticle;
 import com.zerohip.server.financialRecordArticle.repository.FinancialRecordArticleRepository;
 import com.zerohip.server.user.entity.User;
+import com.zerohip.server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,19 +27,17 @@ import java.util.Optional;
 public class FinancialRecordArticleServiceImpl implements FinancialRecordArticleService {
   // 결합도 관련해서 고민이 필요해 보임
   private final FinancialRecordService financialRecordService;
+  private final UserService userService;
   private final FinancialRecordArticleRepository repository;
 
   @Override
-  public FinancialRecordArticle createFaRecArticle(User author, FinancialRecordArticle faRecArticle) {
-    // 로그인된 사용자와 게시글 작성자가 같은지 확인
-    VerifiedAuthor(author, faRecArticle);
-
+  public FinancialRecordArticle createFaRecArticle(Long financialRecordId, User author, FinancialRecordArticle faRecArticle) {
     // 해당 가계부가 존재하는지 확인 -> 없으면 예외를 발생시키고 있으면 해당 가계부를 반환
-    FinancialRecord faRec = financialRecordService.findFaRec(author, faRecArticle.getFinancialRecord().getFinancialRecordId());
+    FinancialRecord faRec = financialRecordService.findFaRec(author, financialRecordId);
 
     // FinancialRecordArticle과 FinancialRecord의 관계를 설정
     faRecArticle.setFinancialRecord(faRec);
-    faRecArticle.setUser(author);
+    faRecArticle.setUser(findUser(author));
 
     // FinancialRecordArticle의 유효성 검사
     validateFaRecArticle(faRecArticle);
@@ -118,5 +117,9 @@ public class FinancialRecordArticleServiceImpl implements FinancialRecordArticle
     if(!author.getLoginId().equals(faRecArticle.getUser().getLoginId())) {
       throw new BusinessLogicException(ExceptionCode.AUTHOR_UNAUTHORIZED);
     }
+  }
+
+  public User findUser(User author) {
+    return userService.findUserByLoginId(author.getLoginId());
   }
 }


### PR DESCRIPTION
## 구현한 기능
========= 가계부 =========
1. Integer형 변수에 @Size()사용불가 -> @Min()
2. 페이지네이션 없는 멀티 response 추가
3. @JoinColumn에 -을 _로 수정
4. 유저 정보를 찾아서 가계부에 유저정보 전체 포함(필요시 일부만 가져오도록 수정 예정)
5. .gitignore ../client/ 추가
========= 가계부 게시글 =========
1. create로직에 가계부 ID파라미터로 받아와서 추가
2. Dto.response에 가계부 ID Entity 가계부 객체에서 ID값을 추출해서 설정하는 로직 추가(Mapper, Dto Setter)


<br/>

## 비고

- 가계부 findFaRecs는 User에 가계부 매핑이 되어 있지 않아 테스트 불가한데 나중에 매핑되면 될듯합니다. 단순 전체 조회라서