### PR TITLE
[FE] !HOTFIX: 모든 데스크탑/태블릿 화면에 margin-left가 적용되는 버그 수정

### DIFF
--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -100,9 +100,9 @@ const S = {
     height: ${(props) => (props.isShowHeader ? 'calc(100% - var(--header-h));' : '100%')};
     margin-top: ${(props) => props.isShowHeader && '5rem'};
     margin-left: ${(props) =>
-      props.windowType === ScreenEnum.DESKTOP
+      props.isShowNav && props.windowType === ScreenEnum.DESKTOP
         ? 'var(--aside-w)'
-        : props.windowType === ScreenEnum.TABLET
+        : props.isShowNav && props.windowType === ScreenEnum.TABLET
         ? 'var(--aside-shrink-w)'
         : '0'};
     display: flex;


### PR DESCRIPTION
# !HOTFIX: 모든 데스크탑/태블릿 화면에 margin-left가 적용되는 버그 수정

`<Main>`의 margin-left에 props.isShowNav 조건을 걸어줬어야 했는데, 그걸 빼먹어서 모든 스크린에 margin-left가 적용된 게 원인이었습니다