### PR TITLE
[BE] OAuth2 로그인 인증 구현

### DIFF
--- a/server/src/main/java/com/zerohip/server/security/auth/controller/AuthController.java
+++ b/server/src/main/java/com/zerohip/server/security/auth/controller/AuthController.java
@@ -36,4 +36,6 @@ public class AuthController {
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+
 }

--- a/server/src/main/java/com/zerohip/server/security/auth/serivce/AuthService.java
+++ b/server/src/main/java/com/zerohip/server/security/auth/serivce/AuthService.java
@@ -1,11 +1,13 @@
 package com.zerohip.server.security.auth.serivce;
 
+import com.zerohip.server.common.exception.BusinessLogicException;
+import com.zerohip.server.common.exception.ExceptionCode;
 import com.zerohip.server.security.auth.entity.RefreshToken;
 import com.zerohip.server.security.auth.repository.RefreshTokenRepository;
 import com.zerohip.server.security.provider.JwtStatus;
 import com.zerohip.server.security.provider.JwtTokenizer;
 import com.zerohip.server.user.entity.User;
-import com.zerohip.server.user.service.UserService;
+import com.zerohip.server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
@@ -24,7 +26,8 @@ public class AuthService {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenizer jwtTokenizer;
-    private final UserService userService;
+//    private final UserServiceImpl userService;
+    private final UserRepository userRepository;
 
     public String createAccessToken(String refreshToken) {
 
@@ -35,7 +38,11 @@ public class AuthService {
         }
 
         Authentication authentication = jwtTokenizer.getAuthentication(refreshToken);
-        User user = userService.findUserByLoginId(authentication.getName());
+//        User user = userService.findUserByLoginId(authentication.getName());
+        Optional<User> optionalUser = userRepository.findUserByLoginId(authentication.getName());
+        User user = optionalUser.orElseThrow(() ->
+                new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+        //
 
         Map<String, Object> claims = new HashMap<>();
         claims.put("loginId", user.getLoginId());
@@ -56,7 +63,11 @@ public class AuthService {
     public void deleteRefreshToken(String refreshToken) {
 
         Authentication authentication = jwtTokenizer.getAuthentication(refreshToken);
-        User user = userService.findUserByLoginId(authentication.getName());
+//        User user = userService.findUserByLoginId(authentication.getName());
+        Optional<User> optionalUser = userRepository.findUserByLoginId(authentication.getName());
+        User user = optionalUser.orElseThrow(() ->
+                new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+        //
 
         RefreshToken findRefreshToken = findVerifiedJwtToken(user.getLoginId());
 

--- a/server/src/main/java/com/zerohip/server/security/config/PasswordEncoderConfig.java
+++ b/server/src/main/java/com/zerohip/server/security/config/PasswordEncoderConfig.java
@@ -1,0 +1,16 @@
+package com.zerohip.server.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/server/src/main/java/com/zerohip/server/security/config/SecurityConfig.java
+++ b/server/src/main/java/com/zerohip/server/security/config/SecurityConfig.java
@@ -8,20 +8,20 @@ import com.zerohip.server.security.handler.UserAccessDeniedHandler;
 import com.zerohip.server.security.handler.UserAuthenticationEntryPoint;
 import com.zerohip.server.security.handler.UserAuthenticationFailureHandler;
 import com.zerohip.server.security.handler.UserAuthenticationSuccessHandler;
+import com.zerohip.server.security.oauth2.handler.OAuth2UserSuccessHandler;
 import com.zerohip.server.security.provider.JwtTokenizer;
 import com.zerohip.server.security.utils.CustomAuthorityUtils;
+import com.zerohip.server.user.repository.UserRepository;
+import com.zerohip.server.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.filter.CorsFilter;
 
@@ -32,21 +32,29 @@ import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @RequiredArgsConstructor
-@Slf4j
 @EnableWebSecurity
 public class SecurityConfig {
+
+//    @Value("${spring.security.oauth2.client.registration.google.clientId}")
+//    private String clientId;
+//
+//    @Value("${spring.security.oauth2.client.registration.google.clientSecret}")
+//    private String clientSecret;
+
 
     private final JwtTokenizer jwtTokenizer;
     private final CustomAuthorityUtils authorityUtils;
     private final CorsFilter corsFilter;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final UserService userService;
+    private final UserRepository userRepository;
 
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-                .headers().frameOptions().sameOrigin().disable() // 주의
+                .headers().frameOptions().sameOrigin().disable() // https 적용 후 수정예정
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
@@ -59,19 +67,23 @@ public class SecurityConfig {
                 .apply(new CustomFilterConfig()) // 커스터마이징 된 CustomFilterConfigurer 추가
                 .and()
                 .authorizeHttpRequests(authorize -> authorize
-                        .anyRequest().permitAll()   // role : user 만 있기 때문에 세부 권한 지정 필요 x
-                );
+                        .anyRequest().permitAll()   // role : 현재 user 권한만 있기 때문에 세부 권한 지정 필요 x
+                )
+                .oauth2Login(oauth2 -> oauth2
+                .successHandler(new OAuth2UserSuccessHandler(jwtTokenizer, authorityUtils, userService, userRepository, refreshTokenRepository)));
+
 
 
         return http.build();
     }
 
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-    }
-
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        return ((web) -> web
+//                .ignoring()
+//                .antMatchers("/courses/{coursesId}/share")
+//                .antMatchers("/posts/read/**"));
+//    }
 
 
     // CustomFilterConfigurer 등록
@@ -95,9 +107,37 @@ public class SecurityConfig {
                     .addFilter(jwtAuthenticationFilter) // Spring Security Filter Chain 에 추가
 
                     // 로그인 인증에 성공한 후 발급받은 JWT가 클라이언트의 request header(Authorization 헤더)에 포함되어 있을 경우에만 동작
-                    .addFilterAfter(jwtVerificationFilter, JwtAuthenticationFilter.class);
+                    .addFilterAfter(jwtVerificationFilter, JwtAuthenticationFilter.class)
+                    .addFilterAfter(jwtVerificationFilter, OAuth2LoginAuthenticationFilter.class);
         }
     }
 
 
+
+//    @Bean
+//    public ClientRegistrationRepository clientRegistrationRepository(OAuth2ClientProperties oAuth2ClientProperties) {
+//        List<ClientRegistration> registrations = oAuth2ClientProperties
+//                .getRegistration().keySet().stream()
+//                .map(client -> getRegistration(oAuth2ClientProperties, client))
+//                .filter(Objects::nonNull)
+//                .collect(Collectors.toList());
+//
+//        return new InMemoryClientRegistrationRepository(registrations);
+//    }
+//
+//    private ClientRegistration getRegistration(OAuth2ClientProperties clientProperties, String client) {
+//
+//        if ("google".equals(client)) {
+//            OAuth2ClientProperties.Registration registration = clientProperties.getRegistration().get("google");
+//
+//            return CommonOAuth2Provider
+//                    .GOOGLE
+//                    .getBuilder(client)
+//                    .clientId(registration.getClientId())
+//                    .clientSecret(registration.getClientSecret())
+//                    .scope("email", "profile")
+//                    .build();
+//        }
+//        return null; // 구글 client 못 찾을 경우
+//    }
 }

--- a/server/src/main/java/com/zerohip/server/security/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/zerohip/server/security/filter/JwtAuthenticationFilter.java
@@ -69,10 +69,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
         // 리프레쉬 토큰 쿠키화
         ResponseCookie cookie = ResponseCookie.from("Refresh", refreshToken)
-                .domain("localhost")
+                .domain("zerohip.co.kr")
                 .maxAge(24 * 60 * 60)
                 .path("/")
-//                .secure(true)
+                .secure(true)
                 .sameSite("None")
                 .httpOnly(true)
                 .build();

--- a/server/src/main/java/com/zerohip/server/security/filter/JwtVerificationFilter.java
+++ b/server/src/main/java/com/zerohip/server/security/filter/JwtVerificationFilter.java
@@ -2,7 +2,6 @@ package com.zerohip.server.security.filter;
 
 import com.zerohip.server.security.provider.JwtTokenizer;
 import com.zerohip.server.security.utils.CustomAuthorityUtils;
-import com.zerohip.server.user.entity.User;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +16,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/server/src/main/java/com/zerohip/server/security/handler/UserAuthenticationFailureHandler.java
+++ b/server/src/main/java/com/zerohip/server/security/handler/UserAuthenticationFailureHandler.java
@@ -5,7 +5,6 @@ import com.zerohip.server.common.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 

--- a/server/src/main/java/com/zerohip/server/security/oauth2/handler/OAuth2UserSuccessHandler.java
+++ b/server/src/main/java/com/zerohip/server/security/oauth2/handler/OAuth2UserSuccessHandler.java
@@ -1,0 +1,158 @@
+package com.zerohip.server.security.oauth2.handler;
+
+import com.zerohip.server.security.auth.entity.RefreshToken;
+import com.zerohip.server.security.auth.repository.RefreshTokenRepository;
+import com.zerohip.server.security.provider.JwtTokenizer;
+import com.zerohip.server.security.utils.CustomAuthorityUtils;
+import com.zerohip.server.user.entity.User;
+import com.zerohip.server.user.repository.UserRepository;
+import com.zerohip.server.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.util.*;
+
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class OAuth2UserSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenizer jwtTokenizer;
+    private final CustomAuthorityUtils authorityUtils;
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        var oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String email = String.valueOf(oAuth2User.getAttributes().get("email"));
+        String loginId = email.substring(0, email.indexOf("@"));
+        String password = randomPassword();
+        String nickname = randomNickname();
+        String provider = String.valueOf(oAuth2User.getAttributes().get("provider"));
+        List<String> authorities = authorityUtils.createRoles(loginId);
+
+        if (userRepository.findUserByEmail(email).isEmpty() && userRepository.findUserByLoginId(loginId).isEmpty()) {
+            saveUser(email, loginId, password, nickname, provider);
+        }
+
+        redirect(request, response, loginId, authorities);
+
+    }
+
+    private void saveUser(String email, String loginId, String password, String nickname, String provider) {
+
+        User user = new User(email, loginId, password, nickname, provider);
+        userService.createUser(user);
+    }
+
+
+
+
+    private String delegateAccessToken(String loginId, List<String> authorities) {
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("loginId", loginId);
+        claims.put("roles", authorities);
+
+        String subject = loginId;
+
+        Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getAccessTokenExpirationMinutes());
+
+        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+        String accessToken = jwtTokenizer.generateAccessToken(claims, subject, expiration, base64EncodedSecretKey);
+
+        return accessToken;
+    }
+
+
+    private String delegateRefreshToken(String loginId) {
+
+        String subject = loginId;
+        Date expiration = jwtTokenizer.getTokenExpiration(jwtTokenizer.getRefreshTokenExpirationMinutes());
+        String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
+
+        String refreshToken = jwtTokenizer.generateRefreshToken(subject, expiration, base64EncodedSecretKey);
+
+        refreshTokenRepository.findByLoginId(loginId)
+                .ifPresentOrElse(
+                        re -> {
+                            re.changeToken(refreshToken);
+                            refreshTokenRepository.save(re);
+                            log.info("# IssueRefreshToken | change token"); // 이미 생성된 토큰이 존재할 경우, 토큰 재발행 후 저장
+                        },
+                        () -> {
+                            RefreshToken token = RefreshToken.createToken(loginId, refreshToken); // 없다면 토큰 생성 후, 저장
+                            refreshTokenRepository.save(token);
+                            log.info("# IssueRefreshToken | save login : {}, token : {}", token.getLoginId(), token.getToken());
+                        });
+
+        return refreshToken;
+    }
+
+
+    // 클라이언트에게 jwt 토큰 전송
+    private void redirect(HttpServletRequest request, HttpServletResponse response, String loginId,
+                          List<String> authorities) throws IOException {
+
+        String accessToken = delegateAccessToken(loginId, authorities);
+        String refreshToken = delegateRefreshToken(loginId);
+
+        String uri = createURI(accessToken, refreshToken).toString();
+        getRedirectStrategy().sendRedirect(request, response, uri);
+    }
+
+
+
+    // 랜덤으로 닉네임 생성
+    private String randomNickname() {
+        String randomNickname = UUID.randomUUID().toString().replaceAll("-", "");
+        int length = Math.min(10, Math.max(4, randomNickname.length()));
+        return randomNickname.substring(0, length);
+    }
+
+    private String randomPassword() {
+        String randomPassword = UUID.randomUUID().toString().replaceAll("-", "");
+        int length = Math.min(16, Math.max(8, randomPassword.length()));
+        return randomPassword.substring(0, length);
+    }
+
+
+    // jwt 토큰 생성 후 클라이언트에게 Redirect . test 후 https 변경 예정
+    private URI createURI(String accessToken, String refreshToken) {
+
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("access_token", accessToken);
+        queryParams.add("refresh_token", refreshToken);
+
+        return UriComponentsBuilder
+                .newInstance()
+//                .scheme("http")
+                .scheme("https")
+//                .host("localhost")
+                .host("zerohip.co.kr")
+//                .path(443)
+                .port(443)
+                .queryParams(queryParams)
+                .build()
+                .toUri();
+    }
+}

--- a/server/src/main/java/com/zerohip/server/security/oauth2/provider/OAuth2Attribute.java
+++ b/server/src/main/java/com/zerohip/server/security/oauth2/provider/OAuth2Attribute.java
@@ -1,0 +1,93 @@
+package com.zerohip.server.security.oauth2.provider;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 인증에 성공 후 받은 사용자 정보 매핑
+ * 각각의 registrationId에 따라 attributes의 정보들을 다르게 추출
+  */
+
+@Slf4j
+@ToString
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class OAuth2Attribute {
+
+    private Map<String, Object> attributes;
+    private String attributeKey;
+    private String provider;
+    private String email;
+
+    public static OAuth2Attribute of(String provider, String attributeKey,
+                                     Map<String, Object> attributes) {
+        switch (provider) {
+            case "google":
+                return ofGoogle(attributeKey, attributes);
+            case "kakao":
+                return ofKakao(attributeKey, attributes);
+            case "naver":
+                return ofNaver(attributeKey, attributes);
+            default:
+                System.out.println("구글, 카카오, 네이버 Oauth2 만 인증 가능");
+                return null;
+        }
+    }
+
+
+    // Oauth2를 통한 사용자 정보 설정을 위한 OAuthAttributes 생성자
+    private static OAuth2Attribute ofGoogle(String attributeKey,
+                                            Map<String, Object> attributes) {
+        return OAuth2Attribute.builder()
+                .email((String) attributes.get("email"))
+                .attributes(attributes)
+                .attributeKey((String) attributes.get(attributeKey))
+                .provider("google")
+                .build();
+    }
+
+
+    private static OAuth2Attribute ofKakao(String attributeKey,
+                                           Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+
+        return OAuth2Attribute.builder()
+                .email((String) kakaoAccount.get("email"))
+                .attributes(kakaoAccount)
+                .attributeKey(String.valueOf(attributes.get(attributeKey)))
+                .provider("kakao")
+                .build();
+    }
+
+    private static OAuth2Attribute ofNaver(String attributeKey,
+                                           Map<String, Object> attributes) {
+        Map<String, Object> naverResponse = (Map<String, Object>) attributes.get("response");
+
+        System.out.println("naverResponse = " + naverResponse);
+
+        return OAuth2Attribute.builder()
+                .email((String) naverResponse.get("email"))
+                .attributes(naverResponse)
+                .attributeKey(String.valueOf(attributes.get(attributeKey)))
+                .provider("naver")
+                .build();
+    }
+
+
+
+    // 사용되는 user entity의 객체 생성
+    public Map<String, Object> convertToMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", attributeKey);
+        map.put("provider", provider);
+        map.put("email", email);
+
+        return map;
+    }
+}

--- a/server/src/main/java/com/zerohip/server/security/oauth2/service/CustomOAuth2UserService.java
+++ b/server/src/main/java/com/zerohip/server/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,50 @@
+package com.zerohip.server.security.oauth2.service;
+
+import com.zerohip.server.security.oauth2.provider.OAuth2Attribute;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+// OAuth2 인증 이후에 인증된 사용자 정보를 처리하는 사용자 서비스
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    // 액세스 토큰 -> 사용자 정보 요청 -> 처리
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+
+        OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest); // OAuth2 사용자 정보
+
+        // userRequest를 통해 사용자의 정보 추출
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // OAuth2 이름( : google, naver, kakao)
+
+        String userNameAttributeName = userRequest.getClientRegistration() // OAuth2 로그인 시, 키 값 ex) sub(google), id(kakao), id(naver)
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        OAuth2Attribute oAuth2Attribute =
+                OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        var userAttribute = oAuth2Attribute.convertToMap();
+        log.info("provider = {}", userAttribute.get("provider")); // OAuth2 명
+
+        // Spring Seucirty의 OAuth2User 구현체 생성하여 반환(OAuth2UserSuccessHandler 사용)
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")), // 사용자 권한 (ROLE_USER 만 사용중)
+                userAttribute, // OAuth2 공급자로부터 받은 사용자 정보를 담고 잇는 Map 객체
+                "id" // 사용자의 식별자를 나타내는 속성 key값
+        );
+    }
+}

--- a/server/src/main/java/com/zerohip/server/security/provider/JwtTokenizer.java
+++ b/server/src/main/java/com/zerohip/server/security/provider/JwtTokenizer.java
@@ -1,7 +1,5 @@
 package com.zerohip.server.security.provider;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerohip.server.security.auth.NeverLandUserDetailsService;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -16,7 +14,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import javax.security.auth.Subject;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Calendar;

--- a/server/src/main/java/com/zerohip/server/user/dto/UserDto.java
+++ b/server/src/main/java/com/zerohip/server/user/dto/UserDto.java
@@ -55,7 +55,7 @@ public class UserDto {
     @Builder
     public static class Patch {
 
-//        private Long UserId;
+        //        private Long UserId;
 //        private String email;
         private String loginId;
 
@@ -126,8 +126,8 @@ public class UserDto {
         private Long userId;
         private String email;
         private String loginId;
-        private String password;
         private String nickname;
+        private String provider;
         private LocalDateTime createdAt;
 
         // 매핑 후 추가

--- a/server/src/main/java/com/zerohip/server/user/entity/User.java
+++ b/server/src/main/java/com/zerohip/server/user/entity/User.java
@@ -26,28 +26,47 @@ public class User extends Auditable {
     @Column(nullable = false, unique = true, updatable = false)
     private String loginId;
 
-    @Column(nullable = false, length = 150)
+    @Column(length = 150)
     private String password;
 
     @Column
     private String nickname;
 
     @Column
-    private String provider;
+    private Provider provider;
 
     public User(String email, String loginId, String password, String nickname, String provider) {
         this.email = email;
         this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
-        this.provider = provider;
+
+        switch (provider) {
+            case "google":
+                this.provider = Provider.GOOGLE;
+                break;
+            case "naver":
+                this.provider = Provider.NAVER;
+                break;
+            case "kakao":
+                this.provider = Provider.KAKAO;
+                break;
+            default:
+                this.provider = null;
+        }
+    }
+
+    @Getter
+    public enum Provider {
+        GOOGLE, NAVER, KAKAO;
     }
 
     @Builder.Default
     @ElementCollection(fetch = FetchType.EAGER)
     private List<String> roles = new ArrayList<>();
 
-  /** 연관관계 매핑
+
+    /** 연관관계 매핑
      *  userImage
      *  faRec
      *  aRecBoard

--- a/server/src/main/java/com/zerohip/server/user/service/UserService.java
+++ b/server/src/main/java/com/zerohip/server/user/service/UserService.java
@@ -14,6 +14,8 @@ public interface UserService {
 
     User findUserByLoginId(String loginId);
 
+    User findUserByEmail(String email);
+
 
     // User 조회(전체)
     List<User> findUsers();

--- a/server/src/main/java/com/zerohip/server/user/service/UserServiceImpl.java
+++ b/server/src/main/java/com/zerohip/server/user/service/UserServiceImpl.java
@@ -56,6 +56,12 @@ public class UserServiceImpl implements UserService{
         return findVerifyUserByLoginId(loginId);
     }
 
+    @Override
+    public User findUserByEmail(String email) {
+
+        return findVerifyUserByEmail(email);
+    }
+
 
     @Override
     public List<User> findUsers() {
@@ -102,6 +108,7 @@ public class UserServiceImpl implements UserService{
         return foundUser;
     }
 
+
     private void verifyExistsLoginId(String loginId) {
 
         Optional<User> user = userRepository.findUserByLoginId(loginId);
@@ -109,6 +116,18 @@ public class UserServiceImpl implements UserService{
             throw new BusinessLogicException(ExceptionCode.LoginId_EXISTS);
         }
     }
+
+
+    private User findVerifyUserByEmail(String email) {
+
+        Optional<User> optionalUser = userRepository.findUserByEmail(email);
+        User foundUser = optionalUser.orElseThrow(() ->
+                new BusinessLogicException(ExceptionCode.USER_NOT_FOUND));
+
+        return foundUser;
+    }
+
+
 
     private void verifyExistsEmail(String email) {
 

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -1,4 +1,48 @@
 spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          # KAKAO Provider
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          # NAVER Provider
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+        registration:
+          # KAKAO Client
+          kakao:
+            client-id: ${KAKAO_REST_API_KEY}
+            client-secret: ${KAKAO_SECRET}
+            redirect-uri: https://zerohip.co.kr/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            scope: account_email
+            client-authentication-method: POST
+
+          # NAVER Client
+          naver:
+            client-id: ${NAVER_CLIENTID}
+            client-secret: ${NAVER_SECRET}
+            scope: email
+            redirect-uri: https://zerohip.co.kr/login/oauth2/code/naver
+            authorization-grant-type: authorization_code
+
+          # Google Client
+          google:
+            clientId: ${GOOGLE_CLIENTID}
+            clientSecret: ${GOOGLE_SECRET}
+            scope:
+              - email
+            redirectUri: https://zerohip.co.kr/login/oauth2/code/google
+            authorization-grant-type: authorization_code
   h2:
     console:
       enabled: true
@@ -36,20 +80,13 @@ server:
   servlet:
     encoding:
       force-response: true
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            clientId: 169242830549-appje0sp82r5s1l19bglnsonk40dv7u0.apps.googleusercontent.com  # 환경변수 ${GOOGLE_CLIENT_ID}
-            clientSecret: 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  # 환경변수 ${GOOGLE_CLIENT_SECRET}
 #mail:
 #  address:
 #    admin: admin@gmail.com
 jwt:
-  key: neverland123123123123123123123123123123 # 환경변수 ${JWT_KEY}
-  access-token-expiration-minutes: 60          # 환경변수 ${JWT_ACCESS_TOKEN}
-  refresh-token-expiration-minutes: 10080      # 환경변수 ${JWT_REFRESH_TOKEN}
+  key: ${JWT_KEY}
+  access-token-expiration-minutes: ${JWT_ACCESS_TOKEN}
+  refresh-token-expiration-minutes: ${JWT_REFRESH_TOKEN}
 cloud:
   aws:
     s3:

--- a/server/src/main/resources/application-prod.yml
+++ b/server/src/main/resources/application-prod.yml
@@ -1,4 +1,48 @@
 spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          # KAKAO Provider
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          # NAVER Provider
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+        registration:
+          # KAKAO Client
+          kakao:
+            client-id: ${KAKAO_REST_API_KEY}
+            client-secret: ${KAKAO_SECRET}
+            redirect-uri: https://zerohip.co.kr/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            scope: account_email
+            client-authentication-method: POST
+
+          # NAVER Client
+          naver:
+            client-id: ${NAVER_CLIENTID}
+            client-secret: ${NAVER_SECRET}
+            scope: email
+            redirect-uri: https://zerohip.co.kr/login/oauth2/code/naver
+            authorization-grant-type: authorization_code
+
+          # Google Client
+          google:
+            clientId: ${GOOGLE_CLIENTID}
+            clientSecret: ${GOOGLE_SECRET}
+            scope:
+              - email
+            redirectUri: https://zerohip.co.kr/login/oauth2/code/google
+            authorization-grant-type: authorization_code
   datasource:
     url: ${MYSQL_SECRET_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
# 구글, 카카오, 네이버 계정으로 로그인 인증 구현

## oauth2 Package
- OAuth2Attribute : OAuth2 인증에 성공 후 받은 사용자 정보 매핑, 각각의 registrationId에 따라 attributes의 정보들을 다르게 추출
- OAuth2UserSuccessHandler - OAuth2 인증 성공 -> user 정보와 매핑 후 저장 (회원가입) -> JWT 토큰 생성 -> redirect
- CustomOAuth2UserService : OAuth2 인증 이후에 인증된 사용자 정보를 처리하는 사용자 서비스

## 기타 참고 사항
- SecurityConfig 설정 변경
- SecurityCorsConfig : test 를 위한 addAllowedOriginPattern () 와일드 카드 사용
- JwtAuthenticationFilter : https 서버 연결을 위한 쿠키 설정
- application-local.yml , prod.yml  OAuth2 구성 및 환경변수 추가

### 구체적인 예외 처리 미구현 -> 추후에 추가 예정