### PR TITLE
[BE] fix: 게시글 수정 시 새로운 글 생성되는 에러 수정

### DIFF
--- a/server/src/main/java/com/zerohip/server/financialRecord/repository/FinancialRecordRepository.java
+++ b/server/src/main/java/com/zerohip/server/financialRecord/repository/FinancialRecordRepository.java
@@ -3,12 +3,13 @@ package com.zerohip.server.financialRecord.repository;
 import com.zerohip.server.financialRecord.entity.FinancialRecord;
 import com.zerohip.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface FinancialRecordRepository extends JpaRepository<FinancialRecord, Long> {
-//  List<FinancialRecord> findByUser(String authorId);
-
-  Optional<List<FinancialRecord>> findByUser(User user);
+  @Query("SELECT fr FROM FinancialRecord fr WHERE fr.user.loginId = :authorId")
+  List<FinancialRecord> findAllByAuthorId(@Param("authorId") String authorId);
 }

--- a/server/src/main/java/com/zerohip/server/financialRecord/service/FinancialRecordServiceImpl.java
+++ b/server/src/main/java/com/zerohip/server/financialRecord/service/FinancialRecordServiceImpl.java
@@ -71,8 +71,7 @@ public class FinancialRecordServiceImpl implements FinancialRecordService {
   // 가계부 전체 조회(동적쿼리 사용 예정)
   @Override
   public List<FinancialRecord> findFaRecs(String authorId) {
-    User findUser = userService.findUserByLoginId(authorId);
-    List<FinancialRecord> financialRecords = findUser.getFinancialRecords();
+    List<FinancialRecord> financialRecords = repository.findAllByAuthorId(authorId);
     log.info("financialRecords : {}", financialRecords.toString());
     return financialRecords;
   }
@@ -103,11 +102,10 @@ public class FinancialRecordServiceImpl implements FinancialRecordService {
       Img img = saveImg(findFaRec, file);
       findFaRec.setProfileImg(img);
     }
-
-    return repository.save(findFaRec);
+    return findFaRec;
   }
 
-  private static void updateFaRecDetails(FinancialRecordDto.Patch patchParam, FinancialRecord findFaRec) {
+  private void updateFaRecDetails(FinancialRecordDto.Patch patchParam, FinancialRecord findFaRec) {
     findFaRec.setFinancialRecordName(patchParam.getFinancialRecordName());
     findFaRec.setMemo(patchParam.getMemo());
   }


### PR DESCRIPTION
1. 게시글 레포지토리에서 쿼리문으로 바로 조회.(쿼리문 최적화 효과)
2. 수정시 Repository.save를 실행X(JPA에서는 수정감지를 해서 자동으로 변경해준다.)

# 비고
- Query를 재설정하면서 중복조회되는 문제점을 해결했으나 정확한 원인은 아직 파악중