### PR TITLE
[FE] common-327: HTTP API 메서드 독립

### DIFF
--- a/client/src/components/SnsArticle.tsx
+++ b/client/src/components/SnsArticle.tsx
@@ -13,7 +13,7 @@ import { FeedArticleResType, FaRecArticleResType, VoteType } from '../types/arti
 import { useWindowType, useWindowSize } from '../hooks/useWindowSize';
 import { ScreenEnum } from '../constants/enums';
 import useUserGlobalValue from './redux/getUserInfo';
-import { APISns } from '../services/apiSns';
+import { APISns, APIVote } from '../services/apiSns';
 import { APIfinancialRecord } from '../services/apiFinancial';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;

--- a/client/src/components/SnsArticle.tsx
+++ b/client/src/components/SnsArticle.tsx
@@ -13,6 +13,8 @@ import { FeedArticleResType, FaRecArticleResType, VoteType } from '../types/arti
 import { useWindowType, useWindowSize } from '../hooks/useWindowSize';
 import { ScreenEnum } from '../constants/enums';
 import useUserGlobalValue from './redux/getUserInfo';
+import { APISns } from '../services/apiSns';
+import { APIfinancialRecord } from '../services/apiFinancial';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -91,11 +93,9 @@ export default function SnsArticle({ type, data }: PropsFeed | PropsTimeline) {
         // 예 (삭제하겠습니다)
         try {
           if (type === 'feed') {
-            const res = await axios.delete(`${BASE_URL}/feedArticles/${data.feedArticleId}`);
+            APISns.deleteFeedArticle(data.feedArticleId);
           } else {
-            const res = await axios.delete(
-              `${BASE_URL}/financialrecord/${data.financialRecordId}/article/${data.financialRecordArticleId}`
-            );
+            APIfinancialRecord.deleteRecordArticle(data.financialRecordId, data.financialRecordArticleId);
           }
         } catch (error) {}
       }

--- a/client/src/components/SnsArticle.tsx
+++ b/client/src/components/SnsArticle.tsx
@@ -1,6 +1,5 @@
 import React from 'react'; // useState 사용
 import styled from '@emotion/styled';
-import axios from 'axios';
 import { useRouter } from 'next/router';
 
 import CommonStyles from '../styles/CommonStyles';
@@ -13,10 +12,8 @@ import { FeedArticleResType, FaRecArticleResType, VoteType } from '../types/arti
 import { useWindowType, useWindowSize } from '../hooks/useWindowSize';
 import { ScreenEnum } from '../constants/enums';
 import useUserGlobalValue from './redux/getUserInfo';
-import { APISns, APIVote } from '../services/apiSns';
+import { APISns } from '../services/apiSns';
 import { APIfinancialRecord } from '../services/apiFinancial';
-
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 /* type은 추후 다른 파일로 분리하고 Import할 예정 */
 type PropsFeed = {

--- a/client/src/components/sns-article/VoteForm.tsx
+++ b/client/src/components/sns-article/VoteForm.tsx
@@ -1,12 +1,9 @@
 import React from 'react'; // useState 사용
 import styled from '@emotion/styled';
-import axios from 'axios';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
-import { APISns, APIVote } from '../../services/apiSns';
+import { APIVote } from '../../services/apiSns';
 import { VoteType } from '../../types/article';
-
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 type Props = {
   feedArticleId: number;

--- a/client/src/components/sns-article/VoteForm.tsx
+++ b/client/src/components/sns-article/VoteForm.tsx
@@ -3,22 +3,18 @@ import styled from '@emotion/styled';
 import axios from 'axios';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
+import { APISns, APIVote } from '../../services/apiSns';
 import { VoteType } from '../../types/article';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
-async function getVote(feedArticleId: number) {
-  const res = await axios.get(`${BASE_URL}/feedArticles/${feedArticleId}/vote`);
-  const voteData: VoteType = res.data;
-  return voteData;
-}
 type Props = {
   feedArticleId: number;
 };
 
 export default function VoteFormComponent(props: Props) {
   const { data, isLoading, isError } = useQuery<VoteType, Error>(['vote', props.feedArticleId], () =>
-    getVote(props.feedArticleId)
+    APIVote.getVote(props.feedArticleId)
   );
 
   const [savingCount, setSavingCount] = React.useState(0);
@@ -32,20 +28,21 @@ export default function VoteFormComponent(props: Props) {
     }
   }, [data]);
 
-  const handleBtnClick = async (e: React.MouseEvent<HTMLButtonElement>, pushed: 'saving' | 'flex') => {
+  const handleBtnClick = async (e: React.MouseEvent<HTMLButtonElement>, voteType: 'SAVING' | 'FLEX') => {
     e.preventDefault();
     try {
-      const res = await axios.get(`${BASE_URL}/feedArticles/${props.feedArticleId}/vote?pushed=${pushed}`);
-      setSavingCount(res.data.savingCount);
-      setFlexCount(res.data.flexCount);
+      APIVote.postVote(props.feedArticleId, voteType);
+      const voteData = await APIVote.getVote(props.feedArticleId);
+      setSavingCount(voteData.savingCount);
+      setFlexCount(voteData.flexCount);
     } catch (error) {}
   };
 
   return (
     <S.VoteForm>
       <S.SavingCount>{savingCount}</S.SavingCount>
-      <S.SavingBtn onClick={(e) => handleBtnClick(e, 'saving')}>👍 절약</S.SavingBtn>
-      <S.FlexBtn onClick={(e) => handleBtnClick(e, 'flex')}>💸 Flex</S.FlexBtn>
+      <S.SavingBtn onClick={(e) => handleBtnClick(e, 'SAVING')}>👍 절약</S.SavingBtn>
+      <S.FlexBtn onClick={(e) => handleBtnClick(e, 'FLEX')}>💸 Flex</S.FlexBtn>
       <S.FlexCount>{flexCount}</S.FlexCount>
     </S.VoteForm>
   );

--- a/client/src/pages/editor/index.tsx
+++ b/client/src/pages/editor/index.tsx
@@ -16,11 +16,6 @@ import { FaRecArticleReqType, FeedArticleReqType } from '../../types/article';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
-async function getFeedArticle(page: number, size: number) {
-  const res = await axios.get(`${BASE_URL}/feedArticles`);
-  return res.data;
-}
-
 function EditorPage() {
   const [isEdit, setIsEdit] = React.useState(false);
   const [articleType, setArticleType] = React.useState(0); // 가계부/절약팁/허락해줘 (라디오 버튼)

--- a/client/src/pages/editor/index.tsx
+++ b/client/src/pages/editor/index.tsx
@@ -13,8 +13,8 @@ import withAuth from '../../components/WithAuth';
 
 import { CATEGORY } from '../../constants/category';
 import { FaRecArticleReqType, FeedArticleReqType } from '../../types/article';
-
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+import { APISns } from '../../services/apiSns';
+import { APIfinancialRecord } from '../../services/apiFinancial';
 
 function EditorPage() {
   const [isEdit, setIsEdit] = React.useState(false);
@@ -96,36 +96,11 @@ function EditorPage() {
       });
 
       if (articleType === 0) {
-        // 가계부
-        const body: FaRecArticleReqType = {
-          financialRecordId: faRecId,
-          category,
-          faDate: faDate.toISOString(),
-          title,
-          price,
-          content,
-          scope: scope === 0 ? '가계부 게시글' : '가계부 타임라인',
-        };
-        formData.append('data', JSON.stringify(body));
-
-        await axios.post(`${BASE_URL}/financialrecord/${faRecId}/article'`, formData, {
-          headers: {
-            'Content-Type': 'multipart/form-data',
-          },
-        });
+        // 가계부 (게시글/타임라인)
+        APIfinancialRecord.postFeedArticle(formData, faRecId, category, faDate, title, price, content, scope);
       } else {
-        // 절약팁/허락해줘
-        const body: FeedArticleReqType = {
-          feedType: articleType === 1 ? '절약팁' : '허락해줘',
-          content,
-        };
-        formData.append('data', JSON.stringify(body));
-
-        await axios.post(`${BASE_URL}/feedArticles`, formData, {
-          headers: {
-            'Content-Type': 'multipart/form-data',
-          },
-        });
+        // SNS (절약팁/허락해줘)
+        APISns.postFeedArticle(formData, articleType, content);
       }
     } catch (error) {
       console.error('Requset 에러 발생:', error);

--- a/client/src/pages/editor/index.tsx
+++ b/client/src/pages/editor/index.tsx
@@ -20,6 +20,9 @@ function EditorPage() {
   const router = useRouter();
 
   const [isEdit, setIsEdit] = React.useState(false);
+  const [faRecArticleId, setFaRecArticleId] = React.useState(NaN);
+  const [feedArticleId, setFeedArticleId] = React.useState(NaN);
+
   const [articleType, setArticleType] = React.useState(0); // 가계부/절약팁/허락해줘 (라디오 버튼)
   /* ↓ 'articleType=가계부'일 경우에만 표시 ↓ */
   const [faRecId, setFaRecId] = React.useState(NaN); // 가계부의 고유번호
@@ -41,24 +44,15 @@ function EditorPage() {
 
     const params = new URLSearchParams(window.location.search);
 
-    const paramFaRecId = params.get('faRecId');
-    const paramFaRecArticleId = params.get('faRecArticleId');
-    const paramFeedArticleId = params.get('feedArticleId');
+    const paramFaRecId = Number(params.get('faRecId'));
+    const paramFaRecArticleId = Number(params.get('faRecArticleId'));
+    const paramFeedArticleId = Number(params.get('feedArticleId'));
+
+    setFaRecId(paramFaRecId || 0);
+    setFaRecArticleId(paramFaRecArticleId);
+    setFeedArticleId(paramFeedArticleId);
 
     setIsEdit(!!(paramFaRecId || paramFaRecArticleId || paramFeedArticleId));
-
-    if (paramFaRecId) {
-      if (paramFaRecArticleId) {
-        // const {} = getFaRecArticle(paramFaRecArticleId);
-      } else {
-        setFaRecId(Number(paramFaRecId));
-      }
-      if (paramFeedArticleId) {
-        // getFeedArticle(paramFeedArticleId);
-      }
-    } else {
-      setFaRecId(0);
-    }
   }, []);
 
   const handleChangeArticleType = (id: number) => {
@@ -104,10 +98,20 @@ function EditorPage() {
 
       if (articleType === 0) {
         // 가계부 (게시글/타임라인)
-        APIfinancialRecord.postFeedArticle(formData, faRecId, category, faDate, title, price, content, scope);
+        APIfinancialRecord.editRecordArticle(
+          formData,
+          faRecId,
+          faRecArticleId,
+          category,
+          faDate,
+          title,
+          price,
+          content,
+          scope
+        );
       } else {
         // SNS (절약팁/허락해줘)
-        APISns.postFeedArticle(formData, articleType, content);
+        APISns.editFeedArticle(feedArticleId, formData, articleType, content);
       }
     } catch (error) {
       console.error('Requset 에러 발생:', error);

--- a/client/src/pages/editor/index.tsx
+++ b/client/src/pages/editor/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-
 import styled from '@emotion/styled';
-import axios from 'axios';
+import { useRouter } from 'next/router';
 
 import CommonStyles from '../../styles/CommonStyles';
 import SelectOption from './SelectOption';
@@ -10,13 +9,16 @@ import InputNaturalNumber from './InputNaturalNumber';
 import RadioSet from './RadioSet';
 import ImgsUploader from './ImgsUploader';
 import withAuth from '../../components/WithAuth';
+import useUserGlobalValue from '../../components/redux/getUserInfo';
 
 import { CATEGORY } from '../../constants/category';
-import { FaRecArticleReqType, FeedArticleReqType } from '../../types/article';
 import { APISns } from '../../services/apiSns';
 import { APIfinancialRecord } from '../../services/apiFinancial';
 
 function EditorPage() {
+  const { isLoggedIn } = useUserGlobalValue();
+  const router = useRouter();
+
   const [isEdit, setIsEdit] = React.useState(false);
   const [articleType, setArticleType] = React.useState(0); // 가계부/절약팁/허락해줘 (라디오 버튼)
   /* ↓ 'articleType=가계부'일 경우에만 표시 ↓ */
@@ -32,6 +34,11 @@ function EditorPage() {
   const [scope, setScope] = React.useState(0); // 가계부에만/타임라인에도
 
   React.useEffect(() => {
+    if (!isLoggedIn) {
+      router.push('/user/login');
+      alert('로그인이 필요합니다.');
+    }
+
     const params = new URLSearchParams(window.location.search);
 
     const paramFaRecId = params.get('faRecId');
@@ -106,6 +113,10 @@ function EditorPage() {
       console.error('Requset 에러 발생:', error);
     }
   };
+
+  if (!isLoggedIn) {
+    return <></>;
+  }
 
   return (
     <S.EditorContainer onSubmit={handleSubmit}>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -13,21 +13,12 @@ import {
   feedArticleDummyB,
 } from '../constants/articleDummyData';
 import { FeedArticleResType } from '../types/article';
+import { APISns } from '../services/apiSns';
 
-const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 const PAGE_SIZE = 10; // 한 번에 가져올 게시글 개수
 
-async function getFeedArticles(page: number, size: number) {
-  const paramsStr = new URLSearchParams(window.location.search).toString();
-  const newQueries = paramsStr === '' ? `page=${page}&size=${size}` : paramsStr; // 홈 | 랭킹(명예의 전당) 구분
-
-  const res = await axios.get(`${BASE_URL}/feedArticles?${newQueries}`);
-  const { data, pageInfo } = res.data;
-  return { data, pageInfo };
-}
-
 export default function HomePage() {
-  const fetchFeedArticles = ({ pageParam = 1 }) => getFeedArticles(pageParam, PAGE_SIZE);
+  const fetchFeedArticles = ({ pageParam = 1 }) => APISns.getFeedArticles(pageParam, PAGE_SIZE);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
     ['feedArticles'],

--- a/client/src/services/apiFinancial.ts
+++ b/client/src/services/apiFinancial.ts
@@ -54,4 +54,10 @@ export const APIfinancialRecord = {
 
     return { data, pageInfo };
   },
+  // 가계부 게시글 DELETE
+  deleteRecordArticle: async (financialRecordId: number, financialRecordArticleId: number) => {
+    const res = await instance.delete(
+      `${BASE_URL}/financialrecord/${financialRecordId}/article/${financialRecordArticleId}`
+    );
+  },
 };

--- a/client/src/services/apiFinancial.ts
+++ b/client/src/services/apiFinancial.ts
@@ -44,6 +44,7 @@ export const APIfinancialRecord = {
     const res = await instance.get(`${BASE_URL}/financialrecord/${financialRecordId}`);
     return res.data;
   },
+
   // 가계부 게시글 GET
   getRecordArticle: async (financialRecordId: number, page: number, size: number) => {
     // const res = await axios.get(
@@ -62,10 +63,11 @@ export const APIfinancialRecord = {
       `${BASE_URL}/financialrecord/${financialRecordId}/article/${financialRecordArticleId}`
     );
   },
-  // 가계부 게시글 POST
-  postFeedArticle: async (
+  // 가계부 게시글 POST or PATCH
+  editRecordArticle: async (
     formData: FormData,
     faRecId: number,
+    faRecArticleId: number,
     category: string,
     faDate: Date,
     title: string,
@@ -73,6 +75,8 @@ export const APIfinancialRecord = {
     content: string,
     scope: number
   ) => {
+    const isPost = isNaN(faRecArticleId);
+
     const body: FaRecArticleReqType = {
       financialRecordId: faRecId,
       category,
@@ -84,10 +88,18 @@ export const APIfinancialRecord = {
     };
     formData.append('data', JSON.stringify(body));
 
-    await instance.post(`${BASE_URL}/financialrecord/${faRecId}/article'`, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    if (isPost) {
+      await instance.post(`${BASE_URL}/financialrecord/${faRecId}/article`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+    } else {
+      await instance.patch(`${BASE_URL}/financialrecord/${faRecId}/article/${faRecArticleId}`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+    }
   },
 };

--- a/client/src/services/apiFinancial.ts
+++ b/client/src/services/apiFinancial.ts
@@ -1,4 +1,6 @@
 import { instance } from './tokenInstance';
+import { FaRecArticleReqType } from '../types/article';
+
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export const APIfinancialRecord = {
@@ -59,5 +61,33 @@ export const APIfinancialRecord = {
     const res = await instance.delete(
       `${BASE_URL}/financialrecord/${financialRecordId}/article/${financialRecordArticleId}`
     );
+  },
+  // 가계부 게시글 POST
+  postFeedArticle: async (
+    formData: FormData,
+    faRecId: number,
+    category: string,
+    faDate: Date,
+    title: string,
+    price: number,
+    content: string,
+    scope: number
+  ) => {
+    const body: FaRecArticleReqType = {
+      financialRecordId: faRecId,
+      category,
+      faDate: faDate.toISOString(),
+      title,
+      price,
+      content,
+      scope: scope === 0 ? '가계부 게시글' : '가계부 타임라인',
+    };
+    formData.append('data', JSON.stringify(body));
+
+    await instance.post(`${BASE_URL}/financialrecord/${faRecId}/article'`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
   },
 };

--- a/client/src/services/apiSns.ts
+++ b/client/src/services/apiSns.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { instance } from './tokenInstance';
 import { VoteType } from '../types/article';
+import { FeedArticleReqType } from '../types/article';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -17,17 +18,31 @@ export const APISns = {
   deleteFeedArticle: async (feedArticleId: number) => {
     const res = await instance.delete(`${BASE_URL}/feedArticles/${feedArticleId}`);
   },
+  // [POST] SNS
+  postFeedArticle: async (formData: FormData, feedType: number, content: string) => {
+    const body: FeedArticleReqType = {
+      feedType: feedType === 1 ? '절약팁' : '허락해줘', // 2: 허락해줘
+      content,
+    };
+    formData.append('data', JSON.stringify(body));
+
+    await axios.post(`${BASE_URL}/feedArticles`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  },
 };
 
 export const APIVote = {
   // [GET] Vote
   getVote: async (feedArticleId: number) => {
-    const res = await axios.get(`${BASE_URL}/vote/${feedArticleId}`);
+    const res = await instance.get(`${BASE_URL}/vote/${feedArticleId}`);
     const voteData: VoteType = res.data;
     return voteData;
   },
   // [POST] 절약/Flex 버튼 눌렀을 시
   postVote: async (feedArticleId: number, voteType: 'SAVING' | 'FLEX') => {
-    const res = await axios.get(`${BASE_URL}/vote/${feedArticleId}?voteType=${voteType}`);
+    const res = await instance.get(`${BASE_URL}/vote/${feedArticleId}?voteType=${voteType}`);
   },
 };

--- a/client/src/services/apiSns.ts
+++ b/client/src/services/apiSns.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-// import { instance } from './tokenInstance';
+import { instance } from './tokenInstance';
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export const APISns = {
@@ -13,6 +13,19 @@ export const APISns = {
   },
   // [DELETE] SNS
   deleteFeedArticle: async (feedArticleId: number) => {
-    const res = await axios.delete(`${BASE_URL}/feedArticles/${feedArticleId}`);
+    const res = await instance.delete(`${BASE_URL}/feedArticles/${feedArticleId}`);
+  },
+};
+
+export const APIVote = {
+  // [GET] Vote
+  getVote: async (feedArticleId: number) => {
+    const res = await axios.get(`${BASE_URL}/vote/${feedArticleId}`);
+    const { data, pageInfo } = res.data;
+    return { data, pageInfo };
+  },
+  // [POST] 절약/Flex 버튼 눌렀을 시
+  postVote: async (feedArticleId: number, voteType: 'SAVING' | 'FLEX') => {
+    const res = await axios.get(`${BASE_URL}/vote/${feedArticleId}?voteType=${voteType}`);
   },
 };

--- a/client/src/services/apiSns.ts
+++ b/client/src/services/apiSns.ts
@@ -18,19 +18,29 @@ export const APISns = {
   deleteFeedArticle: async (feedArticleId: number) => {
     const res = await instance.delete(`${BASE_URL}/feedArticles/${feedArticleId}`);
   },
-  // [POST] SNS
-  postFeedArticle: async (formData: FormData, feedType: number, content: string) => {
+  // [POST] or [PATCH] SNS
+  editFeedArticle: async (feedArticleId: number, formData: FormData, feedType: number, content: string) => {
+    const isPost = isNaN(feedArticleId);
+
     const body: FeedArticleReqType = {
       feedType: feedType === 1 ? '절약팁' : '허락해줘', // 2: 허락해줘
       content,
     };
     formData.append('data', JSON.stringify(body));
 
-    await axios.post(`${BASE_URL}/feedArticles`, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+    if (isPost) {
+      await axios.post(`${BASE_URL}/feedArticles`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+    } else {
+      await axios.patch(`${BASE_URL}/feedArticles/${feedArticleId}`, formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+    }
   },
 };
 

--- a/client/src/services/apiSns.ts
+++ b/client/src/services/apiSns.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 import { instance } from './tokenInstance';
+import { VoteType } from '../types/article';
+
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
 export const APISns = {
@@ -21,8 +23,8 @@ export const APIVote = {
   // [GET] Vote
   getVote: async (feedArticleId: number) => {
     const res = await axios.get(`${BASE_URL}/vote/${feedArticleId}`);
-    const { data, pageInfo } = res.data;
-    return { data, pageInfo };
+    const voteData: VoteType = res.data;
+    return voteData;
   },
   // [POST] 절약/Flex 버튼 눌렀을 시
   postVote: async (feedArticleId: number, voteType: 'SAVING' | 'FLEX') => {

--- a/client/src/services/apiSns.ts
+++ b/client/src/services/apiSns.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+// import { instance } from './tokenInstance';
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+export const APISns = {
+  // [GET] SNS 게시글 (무한 스크롤)
+  getFeedArticles: async (page: number, size: number) => {
+    const paramsStr = new URLSearchParams(window.location.search).toString();
+    const newQueries = paramsStr === '' ? `page=${page}&size=${size}` : paramsStr; // 홈 | 랭킹(명예의 전당) 구분
+    const res = await axios.get(`${BASE_URL}/feedArticles?${newQueries}`);
+    const { data, pageInfo } = res.data;
+    return { data, pageInfo };
+  },
+  // [DELETE] SNS
+  deleteFeedArticle: async (feedArticleId: number) => {
+    const res = await axios.delete(`${BASE_URL}/feedArticles/${feedArticleId}`);
+  },
+};


### PR DESCRIPTION
# [FE] common-327: HTTP API 메서드 독립

## 구현한 기능
1. refactor: 홈 페이지, 게시글 편집 페이지, `<SnsArticle>`, `<VoteForm>` 안에 있는 HTTP 메서드(`GET`/`DELETE`/`PATCH`/`PATCH`)를 `apiFinancial.ts`와 `apiSns.ts`에 각각 독립
2. fix: 최신화된 API 명세서 기준으로 코드 수정
3. fix: 비로그인 상태에서 `/editor`로 접속되는 버그 수정
    - `로그인이 필요합니다.` → 로그인 페이지로 이동
    - 로그인 페이지로 리다이렉트
    - `!isLoggedIn`시 `<></>`를 반환함으로써 페이지 내용물이 표시되지 않도록 적용
4. fix: 오타 수정: 작은따옴표(`'`) 제거
![image](https://github.com/codestates-seb/seb44_main_016/assets/65957855/9e78942f-ce72-47fb-a405-be43419a0493)

5. delete: 사용하지 않는 일부 코드 제거.


<br/>

## 비고
