### PR TITLE
[BE] 프로필이미지 삭제 시 랜덤이미지로 변경하기

### DIFF
--- a/server/src/main/java/com/zerohip/server/common/img/service/ImgService.java
+++ b/server/src/main/java/com/zerohip/server/common/img/service/ImgService.java
@@ -12,15 +12,14 @@ import java.util.List;
 public interface ImgService {
 
   List<Img> createImg(Article article, List<MultipartFile> files) throws IOException;
-
   Img createImg(FinancialRecord faRec, MultipartFile file) throws IOException;
   Img createImg(User user, MultipartFile files) throws IOException;
   Img findImg(Long imgId);
   List<Img> findImgs();
 //  void updateImg(Long imgId, ImgDto.Patch patchParam);
   void deleteImg(Img img);
+  void deleteImg(User user, String deleteImgPath);
   void deleteImgs(Article article, List<String> deleteImgPaths);
-  void deleteImgs(User user, String deleteImgPath);
   Img findVerifiedImg(Long imgId);
   Img findVerifiedImg(String filePath);
 }

--- a/server/src/main/java/com/zerohip/server/common/img/service/S3ImgServiceImpl.java
+++ b/server/src/main/java/com/zerohip/server/common/img/service/S3ImgServiceImpl.java
@@ -132,7 +132,7 @@ public class S3ImgServiceImpl implements ImgService {
   }
 
   @Override
-  public void deleteImgs(User user, String deleteImgPath) {
+  public void deleteImg(User user, String deleteImgPath) {
     Img findImg = imgRepository.findByFilePath(deleteImgPath);
     if (findImg == null) {
       throw new IllegalArgumentException("해당 이미지가 없습니다.");

--- a/server/src/main/java/com/zerohip/server/user/entity/User.java
+++ b/server/src/main/java/com/zerohip/server/user/entity/User.java
@@ -51,7 +51,7 @@ public class User extends Auditable {
 
     @Min(1)
     @Column(nullable = false, unique = false, updatable = false, columnDefinition = "integer default 1")
-    private int RandomAvatarNum;
+    private int randomAvatarNum;
 
     // 테스트 중
     public User(Long userId, String loginId, String nickname, String profileImgPath) {


### PR DESCRIPTION
1. 프로필 이미지 삭제 시 랜덤이미지 (숫자 + 1 씩)적용
2. User Entity에 randomAvatarNum 필드 추가

+ 나중에 회원가입할때 자바코드상에서 랜덤이미지 추가를 바로 하도록 수정해도 될 것 같아요 두 곳에서 처리하지말고