### PR TITLE
[FE] 유저 페이지 SEO 개선 (SSR로 동적 meta 태그 생성 외)

### DIFF
--- a/client/src/components/HeadMeta.tsx
+++ b/client/src/components/HeadMeta.tsx
@@ -11,23 +11,29 @@ export default function HeadMeta({ title, description, url, image }: HeadMetaPro
   return (
     <Head>
       <title>{title || '제로힙'}</title>
-
+      <meta charSet='UTF-8' />
+      <link rel='icon' href='/images/favicon.ico' key='link' />
       <meta
         name='description'
         content={description || '절약유도 가계부형 SNS | 당신의 과소비가 0으로 수렴할 때까지, 제로힙.'}
+        key='description'
       />
       <meta name='viewport' content='initial-scale=1.0, width=device-width' />
 
-      <meta property='og:title' content={title || '제로힙'} />
+      <meta property='og:title' content={title || '제로힙'} key='og:title' />
       <meta
         property='og:description'
         content={description || '절약유도 가계부형 SNS | 당신의 과소비가 0으로 수렴할 때까지, 제로힙.'}
+        key='og:description'
       />
-      <meta property='og:url' content={url || 'https://zerohip.co.kr'} />
-      <meta property='og:image' content={image || 'https://zerohip.co.kr/images/image/zerohipOGImg.png'} />
-      <meta property='og:article:author' content='제로힙' />
+      <meta
+        property='og:image'
+        content={image || 'https://zerohip.co.kr/images/image/zerohipOGImg.png'}
+        key='og:image'
+      />
+      <meta property='og:article:author' content='제로힙' key='og:article' />
 
-      <meta name='twitter:card' content='summary_large_image' />
+      <meta name='twitter:card' content='summary_large_image' key='link' />
     </Head>
   );
 }

--- a/client/src/components/userpage/UserPageInfo.tsx
+++ b/client/src/components/userpage/UserPageInfo.tsx
@@ -5,16 +5,16 @@ import FollowModal from './FollowModal';
 import { UserPageInfoProps } from '../../types/user';
 import { getFollowStatusUserPage } from '../../utils/userpage/getFollowStatus';
 import { useFollowMutations } from '../../hooks/userpage/useFollowMutation';
+import { useFollowStatus } from '../../hooks/userpage';
+import HeadMeta from '../HeadMeta';
+import { USER_META_DATA } from '../../constants/seo/userMetaData';
 
 export default function UserPageInfo({
-  infoData,
-  loginId,
+  userPageData,
+  userId,
   isMyPage,
-  isFollowing,
-  isFollowed,
   isLoggedIn,
-  followingFollowId,
-  followerFollowId,
+  globalLoginId,
 }: UserPageInfoProps) {
   const router = useRouter();
 
@@ -22,15 +22,20 @@ export default function UserPageInfo({
     router.push('/user/update');
   };
 
+  const { isFollowing, isFollowed, followingFollowId, followerFollowId } = useFollowStatus({
+    userPageData,
+    globalLoginId,
+  });
+
   const { cancelFollowingMutate, startFollowingMutate, deleteFollowingMutate } = useFollowMutations(
-    infoData?.nickname
+    userPageData?.nickname
   );
 
   const handleFollowing = () => {
     if (isFollowing && followingFollowId) {
       cancelFollowingMutate(followingFollowId);
-    } else if (loginId) {
-      startFollowingMutate(loginId);
+    } else if (userId) {
+      startFollowingMutate(userId);
     }
   };
 
@@ -42,16 +47,24 @@ export default function UserPageInfo({
 
   return (
     <S.UserProfileContainer>
+      {isMyPage ? (
+        <HeadMeta title={USER_META_DATA.MY_PAGE.TITLE} description={USER_META_DATA.MY_PAGE.DESCRIPTION} />
+      ) : (
+        <HeadMeta
+          title={USER_META_DATA.USER_PAGE.TITLE}
+          description={`제로힙 ${userPageData?.nickname}님의 페이지입니다`}
+        />
+      )}
       <h1 className='blind'>{isMyPage ? '마이페이지' : '유저페이지'}</h1>
       <S.UserProfileImgBox>
-        <img src={infoData?.profileImgPath} alt='프로필 사진' />
+        <img src={userPageData?.profileImgPath} alt='프로필 사진' />
       </S.UserProfileImgBox>
       <S.UserName>
-        <S.Nickname>{infoData?.nickname}</S.Nickname>
+        <S.Nickname>{userPageData?.nickname}</S.Nickname>
       </S.UserName>
       <S.UserSubInfoBox>
-        <FollowModal title='구독함' followList={infoData?.followingList} isMyPage={isMyPage} />
-        <FollowModal title='구독됨' followList={infoData?.followerList} isMyPage={isMyPage} />
+        <FollowModal title='구독함' followList={userPageData?.followingList} isMyPage={isMyPage} />
+        <FollowModal title='구독됨' followList={userPageData?.followerList} isMyPage={isMyPage} />
         {isLoggedIn && (
           <S.UserInfoModifyBtn type='button' onClick={isMyPage ? handleMoveSettingPage : handleFollowing}>
             {followStatusBtnName}

--- a/client/src/constants/oauth/oauth.ts
+++ b/client/src/constants/oauth/oauth.ts
@@ -12,7 +12,6 @@ const RedirectURL = (name: string) => {
 export const naverRedirectURL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${
   OAUTH.NAVER_CLIENT_ID
 }&state=${OAUTH.NAVER_CLIENT_SECRET}&redirect_uri=${RedirectURL('naver')}`;
-console.log(naverRedirectURL);
 
 export const kakaoRedirectURL = `https://kauth.kakao.com/oauth/authorize?client_id=${
   OAUTH.KAKAO_API_KEY

--- a/client/src/constants/seo/userMetaData.ts
+++ b/client/src/constants/seo/userMetaData.ts
@@ -14,6 +14,9 @@ export const USER_META_DATA = {
     DESCRIPTION:
       '내 정보를 확인하고 관리하는 제로힙 마이 페이지입니다. 프로필 사진, 닉네임, 비밀번호 변경 등 다양한 개인 정보 관리가 가능하며, 이때까지 쓴 글을 관리할 수 있습니다.',
   },
+  USER_PAGE: {
+    TITLE: '제로힙 유저 페이지',
+  },
   USER_UPDATE_PAGE: {
     TITLE: '제로힙 회원 정보 수정 페이지',
     DESCRIPTION:

--- a/client/src/hooks/userpage/useCheckIsMyPageFirst.ts
+++ b/client/src/hooks/userpage/useCheckIsMyPageFirst.ts
@@ -3,15 +3,19 @@ import { useEffect } from 'react';
 
 interface useCheckIsMyPageFirstParams {
   globalLoginId: string | undefined | null;
-  loginId: string | string[] | undefined;
+  userIdParam: string | string[] | undefined;
 }
 
-export const useCheckIsMyPageFirst = ({ loginId, globalLoginId }: useCheckIsMyPageFirstParams) => {
+export const useCheckIsMyPageFirst = ({ userIdParam, globalLoginId }: useCheckIsMyPageFirstParams) => {
   const router = useRouter();
+  const isMyPage = userIdParam === globalLoginId;
+
   useEffect(() => {
-    if (loginId === globalLoginId) {
+    if (isMyPage) {
       router.push('/user/mypage');
       return;
     }
-  }, [loginId, globalLoginId]);
+  }, [userIdParam, globalLoginId]);
+
+  return { isMyPage };
 };

--- a/client/src/hooks/userpage/useFollowStatus.ts
+++ b/client/src/hooks/userpage/useFollowStatus.ts
@@ -13,6 +13,8 @@ export const useFollowStatus = ({ userPageData, globalLoginId }: useFollowStatus
   const [followerFollowId, setFollowerFollowId] = useState<number | undefined>(undefined);
 
   useEffect(() => {
+    if (!userPageData) return;
+
     const newIsFollowing = userPageData?.followerList.some(
       (follower: FollowerUsersInfoData) => follower.followerId === globalLoginId
     );

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { useWindowType } from '../hooks/useWindowSize';
 import { ScreenEnum } from '../constants/enums';
 import React from 'react';
+import Head from 'next/head';
 
 const App = ({ Component, pageProps }: AppProps) => {
   const router = useRouter();
@@ -49,6 +50,9 @@ const App = ({ Component, pageProps }: AppProps) => {
             <GlobalStyles />
             <S.RootScreen>
               <S.AppContainer maxWidth={maxWidth}>
+                <Head>
+                  <link rel='icon' href='/favicon.ico' sizes='any' />
+                </Head>
                 <S.FlexPage bgColor={bgColor}>
                   {isShowNav && <Aside />}
                   <S.SubPage>

--- a/client/src/pages/_app.tsx
+++ b/client/src/pages/_app.tsx
@@ -50,9 +50,6 @@ const App = ({ Component, pageProps }: AppProps) => {
             <GlobalStyles />
             <S.RootScreen>
               <S.AppContainer maxWidth={maxWidth}>
-                <Head>
-                  <link rel='icon' href='/favicon.ico' sizes='any' />
-                </Head>
                 <S.FlexPage bgColor={bgColor}>
                   {isShowNav && <Aside />}
                   <S.SubPage>

--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -4,7 +4,9 @@ import { Head, Html, Main, NextScript } from 'next/document';
 const Document = () => {
   return (
     <Html lang='ko'>
-      <Head />
+      <Head>
+        <link rel='icon' href='/images/favicon.ico' />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/client/src/pages/_document.tsx
+++ b/client/src/pages/_document.tsx
@@ -4,10 +4,7 @@ import { Head, Html, Main, NextScript } from 'next/document';
 const Document = () => {
   return (
     <Html lang='ko'>
-      <Head>
-        <meta charSet='UTF-8' />
-        <link rel='icon' href='/images/favicon.ico' />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />

--- a/client/src/pages/user/mypage/index.tsx
+++ b/client/src/pages/user/mypage/index.tsx
@@ -26,7 +26,7 @@ export default function MyPage() {
       <HeadMeta title={USER_META_DATA.MY_PAGE.TITLE} description={USER_META_DATA.MY_PAGE.DESCRIPTION} />
       {myInfoData && (
         <S.Container>
-          <UserPageInfo infoData={myInfoData} isMyPage={true} isLoggedIn={isLoggedIn} />
+          <UserPageInfo userPageData={myInfoData} isMyPage={true} isLoggedIn={isLoggedIn} />
         </S.Container>
       )}
     </>

--- a/client/src/pages/user/profile/[userId]/index.tsx
+++ b/client/src/pages/user/profile/[userId]/index.tsx
@@ -29,7 +29,7 @@ export default function UserPage({ userId: userIdParam }: { userId: string }) {
       {userPageData?.data && globalLoginId && (
         <S.Container>
           <UserPageInfo
-            infoData={userPageData.data}
+            userPageData={userPageData.data}
             isMyPage={userIdParam === globalLoginId}
             isLoggedIn={isLoggedIn}
             userId={userIdParam}

--- a/client/src/services/apiUser.ts
+++ b/client/src/services/apiUser.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import { PostSignUp, LoginReqData, OAuthReqData, UserUpdateReqData } from '../types/user';
 import { instance } from './axios-instance/tokenInstance';
+import { useQuery } from '@tanstack/react-query';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -50,10 +51,16 @@ const apiUser = {
     return response.data;
   },
 
-  /** 회원 기본정보 불러오기 */
+  /** 회원정보 불러오기 */
   getUserPage: async (loginId: string | string[] | undefined) => {
     const response = await instance.get(`${BASE_URL}/user/profile/${loginId}`);
-    return response.data;
+    return response;
+  },
+
+  /** (SSR) 회원정보 불러오기 */
+  useGetUserPage: (loginId: string | string[] | undefined) => {
+    const queryFn = () => apiUser.getUserPage(loginId);
+    return useQuery(['userPage', loginId], queryFn);
   },
 
   /** 내가 쓴 글 불러오기 */

--- a/client/src/types/user.ts
+++ b/client/src/types/user.ts
@@ -126,13 +126,9 @@ export interface UserInfoResData {
 }
 
 export interface UserPageInfoProps {
-  infoData: UserInfoResData;
-  loginId?: string | string[];
+  userPageData: UserInfoResData;
+  userId?: string | string[];
   isMyPage: boolean;
-  isFollowing?: boolean;
-  isFollowed?: boolean;
   isLoggedIn?: boolean;
   globalLoginId?: string;
-  followingFollowId?: number;
-  followerFollowId?: number;
 }


### PR DESCRIPTION
# 유저 페이지 SEO 개선 

<img width="972" alt="image" src="https://github.com/codestates-seb/seb44_main_016/assets/125176463/ecb25284-0efe-423e-b2b0-884a8d8fdba2">

## 구현 기능

### 1. meta 태그 이슈 해결 
- meta 태그가 중복이 되어 2개씩 나타나는 이슈가 있었습니다.
  - 각 meta 태그에 고유한 key 값을 넣어 중복생성되지 않도록 했습니다. 
  - (https://nextjs.org/docs/pages/api-reference/components/head)

### 2. SSR로 동적 meta data 생성
 - 유저 페이지에 접속할 때 미리 SSR에서 데이터를 받아와서 SEO를 개선하고자 했습니다.
 - 향후 필요한 페이지(특히, 게시글 페이지)에 적용할 예정입니다.